### PR TITLE
Set HTTP client timeout options for Lambda invoke calls

### DIFF
--- a/src/adapters/lambda-invocation.js
+++ b/src/adapters/lambda-invocation.js
@@ -8,9 +8,21 @@ const RequestError = require('./helpers/RequestError');
 
 async function lambdaInvocationAdapter (config) {
   const Lambda = config.Lambda || AWS.Lambda;
-  const lambda = new Lambda({
+  const lambdaOptions = {
     endpoint: process.env.LAMBDA_ENDPOINT
-  });
+  };
+
+  if (config.timeout) {
+    // Set some low level HTTP client timeout options
+    // so that the system level resources will be
+    // cleaned up quickly
+    lambdaOptions.httpOptions = {
+      connectTimeout: config.timeout,
+      timeout: config.timeout
+    };
+  }
+
+  const lambda = new Lambda(lambdaOptions);
   const parts = parseLambdaUrl(config.url);
   assert(parts, `The config.url, '${config.url}' does not appear to be a Lambda Function URL`);
 


### PR DESCRIPTION
This change was motivated to avoid the situation shown in the screenshot: 

<img width="959" alt="screen shot 2018-08-23 at 1 52 41 pm" src="https://user-images.githubusercontent.com/106903/44542807-e1bb5780-a6db-11e8-9393-7b7ee7699f9f.png">

In that case, a short timeout was handled at ~900 ms, but the Lambda invoke continued to execute. This new code to set the HTTP level timeouts is here to help the low level systems quickly clean themselves up.