### PR TITLE
Cleanup timers when Lambda invoke completes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "babel-register": "^6.26.0",
     "coveralls": "^3.0.1",
     "eslint": "^5.0.0",
-    "lolex": "^2.7.1",
     "nock": "^9.0.14",
     "nyc": "^12.0.1",
     "proxyquire": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-register": "^6.26.0",
     "coveralls": "^3.0.1",
     "eslint": "^5.0.0",
+    "lolex": "^2.7.1",
     "nock": "^9.0.14",
     "nyc": "^12.0.1",
     "proxyquire": "^2.0.1",

--- a/test/lambda-invocation.test.js
+++ b/test/lambda-invocation.test.js
@@ -3,7 +3,6 @@ const AWS = require('aws-sdk-mock');
 const nock = require('nock');
 const sinon = require('sinon');
 const test = require('ava');
-const lolex = require('lolex');
 const size = require('lodash/size');
 
 test.before(() => {
@@ -450,7 +449,7 @@ test.serial.cb('A configured timeout does not hinder normal lambda function invo
 });
 
 test.serial('A configured timeout does not eat lambda function invocation errors', async (test) => {
-  const clock = lolex.install();
+  const clock = sinon.useFakeTimers();
   try {
     const error = await test.throws(test.context.alpha.get('/some/path', {
       Lambda: delayedLambda(test, 1, new Error('Other error')),
@@ -462,7 +461,7 @@ test.serial('A configured timeout does not eat lambda function invocation errors
 
     test.is(size(clock.timers), 0);
   } finally {
-    clock.uninstall();
+    clock.restore();
   }
 });
 


### PR DESCRIPTION
Be a good citizen to cleanup timers as soon as they are no longer used. Without this change, a process that is 'done' could stay executing until the timeout happens just to wait for the timer to complete and do nothing.