### PR TITLE
Retry Lambda function invocations that time out

### DIFF
--- a/src/adapters/lambda-invocation.js
+++ b/src/adapters/lambda-invocation.js
@@ -42,6 +42,7 @@ async function lambdaInvocationAdapter (config) {
           // ECONNABORTED is the code axios uses for HTTP timeout errors, so this gives
           // a code to consumers which is consistent across HTTP and lambda requests.
           requestError.code = 'ECONNABORTED';
+          requestError.isLambdaInvokeTimeout = true;
           reject(requestError);
 
           awsRequest.abort();

--- a/src/adapters/response-retry.js
+++ b/src/adapters/response-retry.js
@@ -11,6 +11,8 @@ const DEFAULTS = {
 };
 
 function isRetryableError (error) {
+  if (error.isLambdaInvokeTimeout) return true;
+
   return error.code !== 'ECONNABORTED' &&
     (!error.response || (error.response.status >= 500 && error.response.status <= 599));
 }

--- a/test/lambda-invoke-retry.test.js
+++ b/test/lambda-invoke-retry.test.js
@@ -1,0 +1,40 @@
+const Alpha = require('../src/Alpha');
+const nock = require('nock');
+const sinon = require('sinon');
+const test = require('ava');
+
+test.before(() => {
+  nock.disableNetConnect();
+});
+
+test.after(() => {
+  nock.enableNetConnect();
+});
+
+test.serial('Lambda invocations should be retried after a timeout without a custom retryCondition', async (test) => {
+  // Don't provide any response to invoke to mimic is not ever responding
+  const abort = sinon.stub();
+  let invokeCount = 0;
+  const alpha = new Alpha('lambda://test-function', {
+    Lambda: class UnresponsiveLambda {
+      invoke () {
+        invokeCount++;
+        return {
+          promise: function () { return new Promise(function () {}); },
+          abort
+        };
+      }
+    }
+  });
+
+  const request = alpha.get('/some/path', {
+    timeout: 5,
+    retry: {
+      attempts: 2,
+      factor: 1
+    }
+  });
+
+  await test.throws(request);
+  test.is(invokeCount, 3);
+});


### PR DESCRIPTION
This adds a test and fixes the behavior for invocations that combine both timeout and retry options. The client should retry timed out lambda invocations without a custom retryCondition parameter.