### PR TITLE
Allow partial and full function ARNs in the lambda URL scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules/
 .vscode/
 .DS_Store
+/src/adapters/helpers/lambdaURLGrammar.js

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   },
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "buildGrammar": "nearleyc src/adapters/helpers/lambdaURL.ne -o src/adapters/helpers/lambdaURLGrammar.js",
     "lint": "eslint .",
-    "prepare": "yarn run transpile",
-    "pretest": "yarn lint",
+    "prepare": "yarn run transpile && yarn buildGrammar",
+    "pretest": "yarn buildGrammar && yarn lint",
     "test": "nyc ava",
     "transpile": "babel src --out-dir lib"
   },
@@ -42,10 +43,14 @@
     "extends": "plugin:@lifeomic/node/recommended"
   },
   "eslintIgnore": [
-    "/lib/"
+    "/lib/",
+    "src/adapters/helpers/lambdaURLGrammar.js"
   ],
   "nyc": {
     "check-coverage": true,
+    "exclude": [
+      "src/adapters/helpers/lambdaURLGrammar.js"
+    ],
     "lines": 100,
     "statements": 100,
     "functions": 100,
@@ -70,6 +75,7 @@
     "axios": "^0.18.0",
     "docker-lambda": "^0.15.2",
     "lodash": "^4.17.4",
+    "nearley": "^2.16.0",
     "whatwg-url": "^7.0.0"
   },
   "publishConfig": {

--- a/src/adapters/helpers/lambdaURL.ne
+++ b/src/adapters/helpers/lambdaURL.ne
@@ -1,0 +1,26 @@
+@{%
+const flattenDeep = require('lodash/flattenDeep');
+const get = require('lodash/get');
+%}
+
+# Lambda URLs
+lambdaURL -> "lambda://" anyName (":" qualifier):? path:? {%
+  (data) => ({
+      name: flattenDeep(data[1]).join(''),
+      qualifier: flattenDeep(get(data, '[2][1]',  [])).join(''),
+      path: flattenDeep(get(data, '[3]',  [])).join('')
+  })
+%}
+anyName -> functionName
+            | partialArnName
+            | fullArnName
+path -> "/" .:*
+
+# This expression for the funtion name and qualfier was taken from:
+# https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-FunctionName
+functionName -> [a-zA-Z0-9-_]:+
+qualifier -> "$LATEST" | [a-zA-Z0-9-_]:+
+accountId -> [0-9]:+
+region -> [a-zA-Z0-9-_]:+
+partialArnName -> accountId ":function:" functionName
+fullArnName -> "arn:aws:lambda:" region ":" partialArnName

--- a/src/adapters/helpers/parseLambdaUrl.js
+++ b/src/adapters/helpers/parseLambdaUrl.js
@@ -1,18 +1,13 @@
-// This expression for the funtion name and qualfier was taken from:
-// https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-FunctionName
-// eslint-disable-next-line security/detect-unsafe-regex
-const LAMBDA_URL_PATTERN = new RegExp('^lambda://([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?(/.*|$)');
+const nearley = require('nearley');
+const grammar = require('./lambdaURLGrammar');
 
 module.exports = (url) => {
-  const parts = LAMBDA_URL_PATTERN.exec(url);
-
-  if (!parts) {
+  const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+  try {
+    parser.feed(url);
+    const parts = parser.results;
+    return parts[0];
+  } catch (error) {
     return null;
   }
-
-  return {
-    name: parts[1],
-    qualifier: parts[3] || '',
-    path: parts[4] || ''
-  };
 };

--- a/test/parseLambdaUrl.test.js
+++ b/test/parseLambdaUrl.test.js
@@ -6,12 +6,12 @@ test('Parsing an invalid URL returns null', (test) => {
 });
 
 test('Parsing an invalid ARN URL returns null', (test) => {
-  // The ARN as a type in the 'function' segment
+  // The ARN as a typo in the 'function' segment
   test.is(parseLambdaUrl('lambda://arn:aws:lambda:us-west-2:123456789012:func:user-service'), null);
 });
 
 test('Parsing an invalid partial ARN URL returns null', (test) => {
-  // The ARN as a type in the 'function' segment
+  // The ARN as a typo in the 'function' segment
   test.is(parseLambdaUrl('lambda://123456789012:func:user-service'), null);
 });
 
@@ -31,7 +31,7 @@ const NAME_STYLES = [
 ];
 
 for (const {name, description} of NAME_STYLES) {
-  test(`Can ${description}s`, test => {
+  test(`Can parse URLs with ${description}s`, test => {
     test.deepEqual(parseLambdaUrl(`lambda://${name}`), {
       name,
       qualifier: '',
@@ -39,7 +39,7 @@ for (const {name, description} of NAME_STYLES) {
     });
   });
 
-  test(`Can ${description}s with a qualifier`, test => {
+  test(`Can parse URLs with ${description}s and a qualifier`, test => {
     test.deepEqual(parseLambdaUrl(`lambda://${name}:deployed`), {
       name,
       qualifier: 'deployed',
@@ -47,7 +47,7 @@ for (const {name, description} of NAME_STYLES) {
     });
   });
 
-  test(`Can ${description}s with a qualifier and a path`, test => {
+  test(`Can parse URLs with ${description}s, a qualifier and a path`, test => {
     test.deepEqual(parseLambdaUrl(`lambda://${name}:deployed/some/path`), {
       name,
       qualifier: 'deployed',
@@ -55,7 +55,7 @@ for (const {name, description} of NAME_STYLES) {
     });
   });
 
-  test(`Can ${description}s with a $LATEST qualifier and a path`, test => {
+  test(`Can parse URLs with ${description}s, a $LATEST qualifier and a path`, test => {
     test.deepEqual(parseLambdaUrl(`lambda://${name}:$LATEST/some/path`), {
       name,
       qualifier: '$LATEST',
@@ -63,7 +63,7 @@ for (const {name, description} of NAME_STYLES) {
     });
   });
 
-  test(`Can ${description}s with a path`, test => {
+  test(`Can parse ${description}s and a path`, test => {
     test.deepEqual(parseLambdaUrl(`lambda://${name}/some/path`), {
       name,
       qualifier: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,6 +1373,11 @@ commander@^2.11.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
+commander@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
 common-path-prefix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-1.0.0.tgz#cd52f6f0712e0baab97d6f9732874f22f47752c0"
@@ -1629,6 +1634,11 @@ detect-libc@^1.0.2:
 diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
 docker-lambda@^0.15.2:
   version "0.15.2"
@@ -3276,6 +3286,11 @@ module-not-found-error@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+  integrity sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3321,6 +3336,17 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nearley@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.16.0.tgz#77c297d041941d268290ec84b739d0ee297e83a7"
+  integrity sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.4.3"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 needle@^2.2.0:
   version "2.2.1"
@@ -3832,6 +3858,19 @@ qs@^6.5.1, qs@~6.5.1:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This will allow for URLs like:

`lambda://<accountId>:function:<functionName>/`
`lambda://arn:aws:lambda:<region>:<accountId>:function:<functionName>/`