### PR TITLE
chore: pin axios to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.184.0",
-    "axios": "^0.19.0",
+    "axios": "0.19.0",
     "docker-lambda": "^0.15.2",
     "lodash": "^4.17.11",
     "nearley": "^2.16.0",


### PR DESCRIPTION
This is the greenkeeper suggestion for triage, which seems like a great idea while we track down how to play nicely with axios 0.19.1.