### PR TITLE
Adds support for axios 0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.184.0",
-    "axios": "^0.19.0",
+    "axios": "^0.19.1",
     "docker-lambda": "^0.15.2",
     "lodash": "^4.17.11",
     "nearley": "^2.16.0",

--- a/src/adapters/lambda-invocation.js
+++ b/src/adapters/lambda-invocation.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const AWS = require('aws-sdk');
+const isAbsoluteURL = require('./helpers/isAbsoluteURL');
 const chainAdapters = require('./helpers/chainAdapters');
 const lambdaEvent = require('./helpers/lambdaEvent');
 const lambdaResponse = require('./helpers/lambdaResponse');
@@ -23,6 +24,9 @@ async function lambdaInvocationAdapter (config) {
   }
 
   const lambda = new Lambda(lambdaOptions);
+  if (config.baseURL && !isAbsoluteURL(config.url)) {
+    config.url = `${config.baseURL}${config.url}`;
+  }
   const parts = parseLambdaUrl(config.url);
   assert(parts, `The config.url, '${config.url}' does not appear to be a Lambda Function URL`);
 
@@ -89,7 +93,7 @@ async function lambdaInvocationAdapter (config) {
 function lambdaInvocationRequestInterceptor (config) {
   return chainAdapters(
     config,
-    (config) => config.url.startsWith('lambda:'),
+    (config) => config.url.startsWith('lambda:') || (config.baseURL && config.baseURL.startsWith('lambda:')),
     lambdaInvocationAdapter
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,13 +1129,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+axios@0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.1.tgz#8a6a04eed23dfe72747e1dd43c604b8f1677b5aa"
+  integrity sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==
   dependencies:
     follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
 
 babel-plugin-espower@^3.0.1:
   version "3.0.1"
@@ -3010,11 +3009,6 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
-is-buffer@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
-  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-callable@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
Axios adjusted how it handled `url` and `baseURL` in the patch update from 0.19.0 to 0.19.1.  This prevented the `lambda-invocation` adapter from being invoked for certain Alpha configurations.

See [this test](https://github.com/axios/axios/blob/351cf290f0478d6e47e74c6da2f3ad8fe8f29887/test/unit/adapters/http.js#L650) as a reference to what was introduced in the patch.