### PR TITLE
Enable Travis deployment v2 to fix api_key error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
     on_success: never
     on_failure: always
 deploy:
+  edge: true
   provider: npm
   email: $NPM_EMAIL
   api_key: $NPM_KEY


### PR DESCRIPTION
See the error: https://travis-ci.org/lifeomic/alpha/jobs/649510935#L386

Deployment V2 docs: https://docs.travis-ci.com/user/deployment-v2

@aiwilliams figured out this fix on an open source JupiterOne integration so supersized McThankies go to him. Also note, this will require me to cut another patch version so that Travis deploys the changes in the previous PR.