### PR TITLE
LO-6975 - URLs with duplicate parameters are incorrectly parsed by ur…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -1,7 +1,7 @@
 const urlParse = require('url-parse');
 
 module.exports = (config, relativeUrl) => {
-  const parts = urlParse(relativeUrl || config.url, true);
+  const parts = urlParse(relativeUrl || config.url, null, querystringWithArraySupport);
   const params = Object.assign({}, parts.query, config.params);
 
   const event = {
@@ -19,3 +19,49 @@ module.exports = (config, relativeUrl) => {
 
   return event;
 };
+
+/**
+ * This mirrors the simple querystringify parser, except it creates an array of duplicate keys
+ * instead of only using the first key and discarding all subsequent ones, which is how url.parse functioned until urlParse replaced it.
+ * Need to support that array for receiving services to continue functioning correctly (such as multiple _tag keys for FHIR object queries)
+ */
+function querystringWithArraySupport (query) {
+  const parser = /([^=?&]+)=?([^&]*)/g;
+  const result = {};
+
+  let part = parser.exec(query);
+  while (part) {
+    const key = decode(part[1]);
+    const value = decode(part[2]);
+
+    //
+    // Prevent overriding of existing properties. This ensures that build-in
+    // methods like `toString` or __proto__ are not overriden by malicious
+    // querystrings.
+    //
+    // In the case it failed decoding, we want to omit the key/value pairs
+    // from the result.
+    //
+    if (key !== null && value !== null) {
+      if (key in result) {
+        if (!Array.isArray(result[key])) {
+          result[key] = [result[key]];
+        }
+        result[key].push(value);
+      } else {
+        result[key] = value;
+      }
+    }
+    part = parser.exec(query);
+  }
+
+  return result;
+}
+
+function decode (input) {
+  try {
+    return decodeURIComponent(input.replace(/\+/g, ' '));
+  } catch (e) {
+    return null;
+  }
+}

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -1,4 +1,5 @@
 const urlParse = require('url-parse');
+const querystring = require('querystring');
 
 module.exports = (config, relativeUrl) => {
   const parts = urlParse(relativeUrl || config.url, null, querystringWithArraySupport);
@@ -26,42 +27,8 @@ module.exports = (config, relativeUrl) => {
  * Need to support that array for receiving services to continue functioning correctly (such as multiple _tag keys for FHIR object queries)
  */
 function querystringWithArraySupport (query) {
-  const parser = /([^=?&]+)=?([^&]*)/g;
-  const result = {};
-
-  let part = parser.exec(query);
-  while (part) {
-    const key = decode(part[1]);
-    const value = decode(part[2]);
-
-    //
-    // Prevent overriding of existing properties. This ensures that build-in
-    // methods like `toString` or __proto__ are not overriden by malicious
-    // querystrings.
-    //
-    // In the case it failed decoding, we want to omit the key/value pairs
-    // from the result.
-    //
-    if (key !== null && value !== null) {
-      if (key in result) {
-        if (!Array.isArray(result[key])) {
-          result[key] = [result[key]];
-        }
-        result[key].push(value);
-      } else {
-        result[key] = value;
-      }
-    }
-    part = parser.exec(query);
+  if (query.startsWith('?')) {
+    query = query.substring(1);
   }
-
-  return result;
-}
-
-function decode (input) {
-  try {
-    return decodeURIComponent(input.replace(/\+/g, ' '));
-  } catch (e) {
-    return null;
-  }
+  return querystring.parse(query);
 }

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -1,0 +1,73 @@
+const lambdaEvent = require('../src/adapters/helpers/lambdaEvent');
+const test = require('ava');
+
+const duplicateParams = '/lifeomic/dstu3/Questionnaire?pageSize=25&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fquestionnaire-type%7Csurvey-form&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7C0bb18fef-4e2d-4b91-a623-09527265a8b3&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fprimary%7C0343bfcf-4e2d-4b91-a623-095272783bf3';
+const params = '/lifeomic/dstu3/Questionnaire?pageSize=25&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fquestionnaire-type%7Csurvey-form&test=diffValue';
+const invalidValueParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&%E0%A4%A=onlyvalue';
+const invalidKeyParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&onlyKey=%E0%A4%A';
+
+const lambda = `lambda://service:deployed/`;
+const config = {
+  method: 'get',
+  headers: {},
+  url: ''
+};
+
+test.serial(`Can parse URLs with duplicate parameters`, async (test) => {
+  config.url = lambda + duplicateParams;
+  test.deepEqual(lambdaEvent(config, duplicateParams), {
+    body: '',
+    headers: {},
+    httpMethod: 'GET',
+    path: '/lifeomic/dstu3/Questionnaire',
+    queryStringParameters: {
+      _tag: [
+        'http://lifeomic.com/fhir/questionnaire-type|survey-form',
+        'http://lifeomic.com/fhir/dataset|0bb18fef-4e2d-4b91-a623-09527265a8b3',
+        'http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3'
+      ],
+      pageSize: '25'
+    }
+  });
+});
+
+test.serial(`Can parse URLs without duplicates`, async (test) => {
+  config.url = lambda + params;
+  test.deepEqual(lambdaEvent(config, params), {
+    body: '',
+    headers: {},
+    httpMethod: 'GET',
+    path: '/lifeomic/dstu3/Questionnaire',
+    queryStringParameters: {
+      _tag: 'http://lifeomic.com/fhir/questionnaire-type|survey-form',
+      pageSize: '25',
+      test: 'diffValue'
+    }
+  });
+});
+
+test.serial(`Skips invalid keys`, test => {
+  config.url = lambda + invalidKeyParam;
+  test.deepEqual(lambdaEvent(config, invalidKeyParam), {
+    body: '',
+    headers: {},
+    httpMethod: 'GET',
+    path: '/lifeomic/dstu3/Questionnaire',
+    queryStringParameters: {
+      pageSize: '25'
+    }
+  });
+});
+
+test.serial(`Skips invalid values`, test => {
+  config.url = lambda + invalidValueParam;
+  test.deepEqual(lambdaEvent(config, invalidValueParam), {
+    body: '',
+    headers: {},
+    httpMethod: 'GET',
+    path: '/lifeomic/dstu3/Questionnaire',
+    queryStringParameters: {
+      pageSize: '25'
+    }
+  });
+});

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -3,8 +3,8 @@ const test = require('ava');
 
 const duplicateParams = '/lifeomic/dstu3/Questionnaire?pageSize=25&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fquestionnaire-type%7Csurvey-form&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7C0bb18fef-4e2d-4b91-a623-09527265a8b3&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fprimary%7C0343bfcf-4e2d-4b91-a623-095272783bf3';
 const params = '/lifeomic/dstu3/Questionnaire?pageSize=25&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fquestionnaire-type%7Csurvey-form&test=diffValue';
-const invalidValueParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&%E0%A4%A=onlyvalue';
-const invalidKeyParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&onlyKey=%E0%A4%A';
+const invalidValueParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&=onlyvalue';
+const invalidKeyParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&onlyKey=';
 
 const lambda = `lambda://service:deployed/`;
 const config = {
@@ -46,7 +46,7 @@ test.serial(`Can parse URLs without duplicates`, async (test) => {
   });
 });
 
-test.serial(`Skips invalid keys`, test => {
+test.serial(`handles null values`, test => {
   config.url = lambda + invalidKeyParam;
   test.deepEqual(lambdaEvent(config, invalidKeyParam), {
     body: '',
@@ -54,12 +54,13 @@ test.serial(`Skips invalid keys`, test => {
     httpMethod: 'GET',
     path: '/lifeomic/dstu3/Questionnaire',
     queryStringParameters: {
-      pageSize: '25'
+      pageSize: '25',
+      onlyKey: ''
     }
   });
 });
 
-test.serial(`Skips invalid values`, test => {
+test.serial(`handles null keys`, test => {
   config.url = lambda + invalidValueParam;
   test.deepEqual(lambdaEvent(config, invalidValueParam), {
     body: '',
@@ -67,7 +68,8 @@ test.serial(`Skips invalid values`, test => {
     httpMethod: 'GET',
     path: '/lifeomic/dstu3/Questionnaire',
     queryStringParameters: {
-      pageSize: '25'
+      pageSize: '25',
+      '': 'onlyvalue'
     }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,7 +1129,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.19.0:
+axios@^0.19.1:
   version "0.19.2"
   resolved "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,10 +1129,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.1.tgz#8a6a04eed23dfe72747e1dd43c604b8f1677b5aa"
-  integrity sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==
+axios@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
 


### PR DESCRIPTION
I found this issue tracking down an issue in `survey-service` where Alpha requests were being made to `patient-service` with multiple `_tag` query params

 When running querystring.stringify(query) on an array of params, the following code 
```
_tag: [
      `${codes.formType}|${codes.surveyResponse}`,
      `${codes.dataset}|${projectId}`,
    ]
```
would produce:

`/lifeomic/dstu3/QuestionnaireResponse?pageSize=25&`**_tag**`=http%3A%2F%2Flifeomic.com%2Ffhir%2Fquestionnaire-type%7Csurvey-form&`**_tag**`=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7C0bb18fef-4e2d-4b91-a623-09527265a8b3`

When the request was sent to Alpha, the urlParser would only parse a given queryParm once and ignore any subsequent duplicate keys. Because of this, in the above example, the dataset param in the second tag was never making it to `patient-service`, which then caused a query timeout issue on reading from the database (as I believe it wasn't able to use the index).

This issue was introduced in @lifeomic/Alpha on 9/3/2019 version 1.0.1 when 
```
const url = require('url');
const parts = url.parse(relativeUrl || config.url, true);
```

was replaced with 

```
const urlParse = require('url-parse');
const parts = urlParse(relativeUrl || config.url, true);
```

url.parse would bundle duplicate params together in an array and send them on to the receiving service. And as such, any service using an alpha version older than 1.0.1 still functions correctly. 
For example, survey-service by and large uses @lifeomic/koa to make REST calls and @Lifeomic/koa uses Alpha 0.12.1. But when `survey-service` uses @Lifeomic/alpha directly, it's using version `1.1.0`.

(`url-parse` was put in to replace `url` because `url` was being deprecated.)

My code changes provide a customized querystringparser that is passed into urlParser. The code in the customParser is the same as the querystringify parser except it builds out an array of duplicate keys instead of ignoring them like `url.parse(relativeUrl || config.url, true)` used to do.

