### PR TITLE
support both callback and promise style local test handler

### DIFF
--- a/src/adapters/helpers/promisify.js
+++ b/src/adapters/helpers/promisify.js
@@ -9,6 +9,16 @@ module.exports = (fn) => {
     };
 
     parameters.push(callback);
-    fn(...parameters);
+
+    // This ensure both callback and promise style functions are supported.
+    // 1) If fn is promise style, fn will ignore the always-passed callback
+    // function. Thus, after finishing, we need to call through to
+    // resolve/reject functions by using resolve + then() here.
+    // 2) If fn is callback style, it'll call resolve/reject in the callback
+    // function above which in turn resolves this promise. Because resolve/reject
+    // were called in the callback, .then() will also call the same resolve or
+    // reject a second time. However, this is okay because calling resolve/reject
+    // multiple times is a no-opt.
+    return Promise.resolve(fn(...parameters)).then(resolve, reject);
   });
 };

--- a/src/adapters/helpers/promisify.js
+++ b/src/adapters/helpers/promisify.js
@@ -19,6 +19,6 @@ module.exports = (fn) => {
     // were called in the callback, .then() will also call the same resolve or
     // reject a second time. However, this is okay because calling resolve/reject
     // multiple times is a no-opt.
-    return Promise.resolve(fn(...parameters)).then(resolve, reject);
+    Promise.resolve(fn(...parameters)).then(resolve, reject);
   });
 };

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -16,178 +16,235 @@ test.beforeEach((test) => {
   test.context.client = new Alpha(test.context.handler);
 });
 
-test('Making a GET request to a local handler invokes the handler', async (test) => {
-  const response = {
-    headers: { 'test-header': 'some value' },
-    body: 'hello!',
-    statusCode: 200
-  };
+function setupHandlerBehavior ({ handlerStub, isCallbackStyleHandler, error, response }) {
+  if (isCallbackStyleHandler) {
+    handlerStub.callsArgWith(2, error, response);
+  } else {
+    error ? handlerStub.rejects(error) : handlerStub.resolves(response);
+  }
+}
 
-  test.context.handler.callsArgWith(2, null, response);
-  const result = await test.context.client.get('/some/path');
+function registerSpecs (isCallbackStyleHandler) {
+  test(`Making a GET request to a local handler invokes the handler (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+    const response = {
+      headers: { 'test-header': 'some value' },
+      body: 'hello!',
+      statusCode: 200
+    };
 
-  test.is(result.status, 200);
-  test.deepEqual(result.headers, response.headers);
-  test.is(result.data, response.body);
+    setupHandlerBehavior({
+      handlerStub: test.context.handler,
+      isCallbackStyleHandler,
+      response
+    });
+    const result = await test.context.client.get('/some/path');
 
-  const event = {
-    body: '',
-    headers: sinon.match.object,
-    httpMethod: 'GET',
-    path: '/some/path',
-    queryStringParameters: {}
-  };
+    test.is(result.status, 200);
+    test.deepEqual(result.headers, response.headers);
+    test.is(result.data, response.body);
 
-  const context = {};
-
-  test.true(test.context.handler.calledWith(event, context, sinon.match.func));
-});
-
-test('When a local handler returns an error the request fails', async (test) => {
-  const failure = new Error('simulated failure');
-  test.context.handler.callsArgWith(2, failure);
-
-  const error = await test.throwsAsync(() => test.context.client.get('/some/path'));
-
-  test.is(error.message, failure.message);
-
-  test.truthy(error.config);
-  test.is(error.config.url, '/some/path');
-
-  test.is(error.response, undefined);
-
-  test.truthy(error.request);
-  test.is(error.request.event.body, '');
-  test.truthy(error.request.event.headers);
-  test.is(error.request.event.httpMethod, 'GET');
-  test.is(error.request.event.path, '/some/path');
-  test.deepEqual(error.request.event.queryStringParameters, {});
-
-  test.false(Object.keys(error).includes('code'));
-  test.true(test.context.handler.called);
-});
-
-test('When status validation is disable errors are not thrown', async (test) => {
-  const response = {
-    body: 'error!',
-    statusCode: 400
-  };
-
-  test.context.handler.callsArgWith(2, null, response);
-  const result = await test.context.client.get('/some/path', { validateStatus: false });
-
-  test.is(result.status, response.statusCode);
-  test.is(result.data, response.body);
-});
-
-test('Redirects are automaticaly followed (301)', async (test) => {
-  const redirect = {
-    headers: { location: '/other/path' },
-    statusCode: 301
-  };
-
-  const response = {
-    body: 'hello!',
-    statusCode: 200
-  };
-
-  test.context.handler.onFirstCall().callsArgWith(2, null, redirect);
-  test.context.handler.onSecondCall().callsArgWith(2, null, response);
-
-  const result = await test.context.client.get('/some/path');
-
-  test.is(result.status, 200);
-  test.is(result.data, response.body);
-
-  test.true(test.context.handler.firstCall.calledWith(
-    {
+    const event = {
       body: '',
       headers: sinon.match.object,
       httpMethod: 'GET',
       path: '/some/path',
       queryStringParameters: {}
-    },
-    {},
-    sinon.match.func
-  ));
+    };
 
-  test.true(test.context.handler.secondCall.calledWith(
-    {
-      body: '',
+    const context = {};
+
+    sinon.assert.calledWithExactly(
+      test.context.handler,
+      event,
+      context,
+      sinon.match.func
+    );
+  });
+
+  test(`When a local handler returns an error the request fails (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+    const failure = new Error('simulated failure');
+    setupHandlerBehavior({
+      handlerStub: test.context.handler,
+      error: failure,
+      isCallbackStyleHandler
+    });
+
+    const error = await test.throwsAsync(() => test.context.client.get('/some/path'));
+
+    test.is(error.message, failure.message);
+
+    test.truthy(error.config);
+    test.is(error.config.url, '/some/path');
+
+    test.is(error.response, undefined);
+
+    test.truthy(error.request);
+    test.is(error.request.event.body, '');
+    test.truthy(error.request.event.headers);
+    test.is(error.request.event.httpMethod, 'GET');
+    test.is(error.request.event.path, '/some/path');
+    test.deepEqual(error.request.event.queryStringParameters, {});
+
+    test.false(Object.keys(error).includes('code'));
+    test.true(test.context.handler.called);
+  });
+
+  test(`When status validation is disable errors are not thrown (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+    const response = {
+      body: 'error!',
+      statusCode: 400
+    };
+
+    setupHandlerBehavior({
+      handlerStub: test.context.handler,
+      response,
+      isCallbackStyleHandler
+    });
+
+    const result = await test.context.client.get('/some/path', { validateStatus: false });
+
+    test.is(result.status, response.statusCode);
+    test.is(result.data, response.body);
+  });
+
+  test(`Redirects are automaticaly followed (301) (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+    const redirect = {
+      headers: { location: '/other/path' },
+      statusCode: 301
+    };
+
+    const response = {
+      body: 'hello!',
+      statusCode: 200
+    };
+
+    setupHandlerBehavior({
+      handlerStub: test.context.handler.onFirstCall(),
+      response: redirect,
+      isCallbackStyleHandler
+    });
+    setupHandlerBehavior({
+      handlerStub: test.context.handler.onSecondCall(),
+      response,
+      isCallbackStyleHandler
+    });
+
+    const result = await test.context.client.get('/some/path');
+
+    test.is(result.status, 200);
+    test.is(result.data, response.body);
+
+    sinon.assert.calledWithExactly(
+      test.context.handler.firstCall,
+      {
+        body: '',
+        headers: sinon.match.object,
+        httpMethod: 'GET',
+        path: '/some/path',
+        queryStringParameters: {}
+      },
+      {},
+      sinon.match.func
+    );
+    sinon.assert.calledWithExactly(
+      test.context.handler.secondCall,
+      {
+        body: '',
+        headers: sinon.match.object,
+        httpMethod: 'GET',
+        path: '/other/path',
+        queryStringParameters: {}
+      },
+      {},
+      sinon.match.func
+    );
+  });
+
+  test(`Redirects are automaticaly followed (302) (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+    const redirect = {
+      headers: { location: '/other/path' },
+      statusCode: 302
+    };
+
+    const response = {
+      body: 'hello!',
+      statusCode: 200
+    };
+
+    setupHandlerBehavior({
+      handlerStub: test.context.handler.onFirstCall(),
+      response: redirect,
+      isCallbackStyleHandler
+    });
+    setupHandlerBehavior({
+      handlerStub: test.context.handler.onSecondCall(),
+      response,
+      isCallbackStyleHandler
+    });
+
+    const result = await test.context.client.get('/some/path');
+
+    test.is(result.status, 200);
+    test.is(result.data, response.body);
+
+    sinon.assert.calledWithExactly(
+      test.context.handler.firstCall,
+      {
+        body: '',
+        headers: sinon.match.object,
+        httpMethod: 'GET',
+        path: '/some/path',
+        queryStringParameters: {}
+      },
+      {},
+      sinon.match.func
+    );
+    sinon.assert.calledWithExactly(
+      test.context.handler.secondCall,
+      {
+        body: '',
+        headers: sinon.match.object,
+        httpMethod: 'GET',
+        path: '/other/path',
+        queryStringParameters: {}
+      },
+      {},
+      sinon.match.func
+    );
+  });
+
+  test(`Binary content is base64 encoded (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+    const content = Buffer.from('hello!');
+
+    const response = {
+      statusCode: 204
+    };
+
+    setupHandlerBehavior({
+      handlerStub: test.context.handler,
+      response,
+      isCallbackStyleHandler
+    });
+    const result = await test.context.client.put('/some/path', content);
+
+    test.is(result.status, 204);
+
+    const event = {
+      body: content.toString('base64'),
       headers: sinon.match.object,
-      httpMethod: 'GET',
-      path: '/other/path',
-      queryStringParameters: {}
-    },
-    {},
-    sinon.match.func
-  ));
-});
-
-test('Redirects are automaticaly followed (302)', async (test) => {
-  const redirect = {
-    headers: { location: '/other/path' },
-    statusCode: 302
-  };
-
-  const response = {
-    body: 'hello!',
-    statusCode: 200
-  };
-
-  test.context.handler.onFirstCall().callsArgWith(2, null, redirect);
-  test.context.handler.onSecondCall().callsArgWith(2, null, response);
-
-  const result = await test.context.client.get('/some/path');
-
-  test.is(result.status, 200);
-  test.is(result.data, response.body);
-
-  test.true(test.context.handler.firstCall.calledWith(
-    {
-      body: '',
-      headers: sinon.match.object,
-      httpMethod: 'GET',
+      httpMethod: 'PUT',
+      isBase64Encoded: true,
       path: '/some/path',
       queryStringParameters: {}
-    },
-    {},
-    sinon.match.func
-  ));
+    };
 
-  test.true(test.context.handler.secondCall.calledWith(
-    {
-      body: '',
-      headers: sinon.match.object,
-      httpMethod: 'GET',
-      path: '/other/path',
-      queryStringParameters: {}
-    },
-    {},
-    sinon.match.func
-  ));
-});
-
-test('Binary content is base64 encoded', async (test) => {
-  const content = Buffer.from('hello!');
-
-  const response = {
-    statusCode: 204
-  };
-
-  test.context.handler.callsArgWith(2, null, response);
-  const result = await test.context.client.put('/some/path', content);
-
-  test.is(result.status, 204);
-
-  const event = {
-    body: content.toString('base64'),
-    headers: sinon.match.object,
-    httpMethod: 'PUT',
-    isBase64Encoded: true,
-    path: '/some/path',
-    queryStringParameters: {}
-  };
-
-  sinon.assert.calledWithExactly(test.context.handler, event, {}, sinon.match.func);
-});
+    sinon.assert.calledWithExactly(
+      test.context.handler,
+      event,
+      {},
+      sinon.match.func
+    );
+  });
+}
+registerSpecs(true);
+registerSpecs(false);


### PR DESCRIPTION
This is to make testing easier for consuming projects. Our internal shared serverless-http based Koa app only exports a promise-style handler function now. Previously, Alpha only supported callback style because the injected callback below would never get called for a promise style handler. The new way will allow for either.