### PR TITLE
Export more types to avoid mismatch with axios version juggling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.3] - 2020-10-07
+## [1.3.0] - 2020-11-11
+### Added
+- Exposed `AlphaInstance`, `AlphaOptions` so that consuming projects don't have
+juggle different versions of `axios` (`AxiosInstance`).
 
+## [1.2.3] - 2020-10-07
+### Fixed
 - Fixed issue with asynchronously invoked callbacks when using the "Lambda Handler Targets".
 
 ## [1.2.1] - 2020-07-31
-
 ### Fixed
-
 - Upgraded `axios` to fix bug that caused default query params to get ignored
 
+[1.3.0]: https://github.com/lifeomic/cli/compare/v1.2.3...v1.3.0
+[1.2.3]: https://github.com/lifeomic/cli/compare/v1.2.2...v1.2.3
 [1.2.1]: https://github.com/lifeomic/cli/compare/v1.2.0...v1.2.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "1.2.3",
+  "version": "1.3.0-0",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/src/Alpha.d.ts
+++ b/src/Alpha.d.ts
@@ -1,5 +1,5 @@
 declare module '@lifeomic/alpha' {
-  import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+  import { AxiosInstance, AxiosRequestConfig } from 'axios';
 
   interface RetryOptions {
     attempts?: number,
@@ -8,18 +8,18 @@ declare module '@lifeomic/alpha' {
     retryCondition?: (err: Error) => boolean
   }
 
-  interface AlphaOptions extends AxiosRequestConfig {
+  export interface AlphaOptions extends AxiosRequestConfig {
     retry?: RetryOptions,
     lambda?: Function
   }
 
-  type AlphaClient = AxiosInstance;
+  export type AlphaInstance = AxiosInstance;
 
   interface AlphaConstructor {
-    new (target: string | Function, options?: AlphaOptions): AlphaClient;
-    new (options: AlphaOptions): AlphaClient;
+    new (target: string | Function, options?: AlphaOptions): AlphaInstance;
+    new (options: AlphaOptions): AlphaInstance;
   }
 
-  const Alpha: AlphaConstructor;
-  export = Alpha;
+  // default export
+  export = AlphaConstructor;
 }


### PR DESCRIPTION
It's common for consumers to import `AxiosInstance` from `axios` to properly type instances of `Alpha`. By not exporting from `@lifeomic/alpha` directly, it's very easy to have a mismatch between alpha's version of axios types and the consuming project's root level version of axios types. Using the exposed type should help avoid a lot of mismatches.