### PR TITLE
Fix types - move away from module declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2020-11-12
+### Fixed
+- Move away from module declarations due to limitations (cannot export types
+in addition to a default export).
+
 ## [1.3.0] - 2020-11-11
 ### Added
 - Exposed `AlphaInstance`, `AlphaOptions` so that consuming projects don't have
@@ -18,6 +23,7 @@ juggle different versions of `axios` (`AxiosInstance`).
 ### Fixed
 - Upgraded `axios` to fix bug that caused default query params to get ignored
 
+[1.3.1]: https://github.com/lifeomic/cli/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/lifeomic/cli/compare/v1.2.3...v1.3.0
 [1.2.3]: https://github.com/lifeomic/cli/compare/v1.2.2...v1.2.3
 [1.2.1]: https://github.com/lifeomic/cli/compare/v1.2.0...v1.2.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "1.3.0-0",
+  "version": "1.3.1-0",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/src/Alpha.d.ts
+++ b/src/Alpha.d.ts
@@ -1,25 +1,23 @@
-declare module '@lifeomic/alpha' {
-  import { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
 
-  interface RetryOptions {
-    attempts?: number,
-    factor?: number,
-    maxTimeout?: number,
-    retryCondition?: (err: Error) => boolean
-  }
-
-  export interface AlphaOptions extends AxiosRequestConfig {
-    retry?: RetryOptions,
-    lambda?: Function
-  }
-
-  export type AlphaInstance = AxiosInstance;
-
-  interface AlphaConstructor {
-    new (target: string | Function, options?: AlphaOptions): AlphaInstance;
-    new (options: AlphaOptions): AlphaInstance;
-  }
-
-  // default export
-  export = AlphaConstructor;
+interface RetryOptions {
+  attempts?: number,
+  factor?: number,
+  maxTimeout?: number,
+  retryCondition?: (err: Error) => boolean
 }
+
+export interface AlphaOptions extends AxiosRequestConfig {
+  retry?: RetryOptions,
+  lambda?: Function
+}
+
+export type AlphaInstance = AxiosInstance;
+
+interface AlphaConstructor {
+  new (target: string | Function, options?: AlphaOptions): AlphaInstance;
+  new (options: AlphaOptions): AlphaInstance;
+}
+
+declare const Alpha: AlphaConstructor;
+export default Alpha;


### PR DESCRIPTION
This is a follow-up to https://github.com/lifeomic/alpha/pull/69

I thought I linked/tested the previous change and it worked. I think I forgot to run `yarn prepare` when linking in the consuming project. I verified three times, this time :)

Module declarations don't support a default export in addition to named exports: `An export assignment cannot be used in a module with other exported elements.`

I can't think of a good reason to use the `declare module` syntax here (I generally avoid this pattern elsewhere), but I'm also not a TS expert. I'd love to get feedback from at least a couple of people in case I'm missing something obvious here. 
