### PR TITLE
Fixed a url parsing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2020-02-18
+### Fixed
+- Fixed a url parsing bug exposed by the newest url-parse module which caused
+the URL passed to the lambda to be missing a leading forward slash.
+
 ## [1.3.1] - 2020-11-12
 ### Fixed
 - Move away from module declarations due to limitations (cannot export types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lodash": "^4.17.20",
     "nearley": "^2.19.7",
     "resolve-pathname": "^3.0.0",
-    "url-parse": "^1.4.7"
+    "url-parse": "^1.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -2,7 +2,8 @@ const urlParse = require('url-parse');
 const querystring = require('querystring');
 
 module.exports = (config, relativeUrl) => {
-  const parts = urlParse(relativeUrl || config.url, null, querystringWithArraySupport);
+  // url-parse needs a location to properly handle relative urls, so provide a fake one here:
+  const parts = urlParse(relativeUrl || config.url, 'http://fake', querystringWithArraySupport);
   const params = Object.assign({}, parts.query, config.params);
 
   const event = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,10 +5754,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
-  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+url-parse@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.0.tgz#90aba6c902aeb2d80eac17b91131c27665d5d828"
+  integrity sha512-9iT6N4s93SMfzunOyDPe4vo4nLcSu1yq0IQK1gURmjm8tQNlM6loiuCRrKG1hHGXfB2EWd6H4cGi7tGdaygMFw==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
Fixed a url parsing bug  exposed by the newest url-parse module which
caused the URL passed to the lambda to be missing a leading forward
slash.