### PR TITLE
LO-1156 - Reduce risk of performance degradation on urls with large query string params

### DIFF
--- a/src/adapters/helpers/parseLambdaUrl.js
+++ b/src/adapters/helpers/parseLambdaUrl.js
@@ -4,8 +4,13 @@ const grammar = require('./lambdaURLGrammar');
 module.exports = (url) => {
   const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
   try {
-    parser.feed(url);
+    // large query strings can slow the parser down significantly
+    const urlSplitOnQuery = url.split('?');
+    parser.feed(urlSplitOnQuery.shift());
     const parts = parser.results;
+    if (urlSplitOnQuery.length) {
+      parts[0].path += `?${urlSplitOnQuery.join('?')}`;
+    }
     return parts[0];
   } catch (error) {
     return null;

--- a/test/parseLambdaUrl.test.js
+++ b/test/parseLambdaUrl.test.js
@@ -63,11 +63,27 @@ for (const { name, description } of NAME_STYLES) {
     });
   });
 
+  test(`Can parse URLs with ${description}s, a $LATEST qualifier and a path and a query string`, test => {
+    test.deepEqual(parseLambdaUrl(`lambda://${name}:$LATEST/some/path?key1=value1`), {
+      name,
+      qualifier: '$LATEST',
+      path: '/some/path?key1=value1'
+    });
+  });
+
   test(`Can parse ${description}s and a path`, test => {
     test.deepEqual(parseLambdaUrl(`lambda://${name}/some/path`), {
       name,
       qualifier: '',
       path: '/some/path'
+    });
+  });
+
+  test(`Can parse ${description}s and a path and a query string with multiple params`, test => {
+    test.deepEqual(parseLambdaUrl(`lambda://${name}/some/path?key1=value1&key2=value2&key3=value3`), {
+      name,
+      qualifier: '',
+      path: '/some/path?key1=value1&key2=value2&key3=value3'
     });
   });
 }


### PR DESCRIPTION
Background:

`cohorts-service` is doing validation that all patients in a cohort belong to the same project as the cohort. For sufficiently large cohorts with thousands of patients this can take several seconds to perform the validation because of a delay in retrieving the patients from `patient-service`.

However, using Axios to request the patients from `patient-service` instead of Alpha can reduce that time to a second.

I ran some benchmarks in Alpha and found that the Nearley parser is the bottleneck. By removing the query string from the url before parsing it and then appending it to the end of the path part afterward reduces the time back down to a second. Admittedly, I'm not the biggest fan of this solution. 

Other options; 
* Use Axios instead of Alpha to do the validation in cohorts-service.
* Look into using a tokenizer in nearley to handle "ignoring" the query param. (I started going down this path, but was spending a lot of time just researching how to implement it and wasn't confident that it would improve performance enough)
* Do nothing and just live with the extra time it takes to create large cohorts (I did play around with adjusting the concurrency and batch size in cohorts-service to try and optimize the performance there, but didn't see any noticeable gains)

(If this PR does pass muster, I'll update the versioning in a subsequent PR)