### PR TITLE
Set default lambda timeout to 15 minutes

### DIFF
--- a/src/adapters/lambda-invocation.js
+++ b/src/adapters/lambda-invocation.js
@@ -7,6 +7,8 @@ const lambdaResponse = require('./helpers/lambdaResponse');
 const parseLambdaUrl = require('./helpers/parseLambdaUrl');
 const RequestError = require('./helpers/RequestError');
 
+const LAMBDA_MAX_TIMEOUT = 15 * 60 * 1000;
+
 async function lambdaInvocationAdapter (config) {
   const Lambda = config.Lambda || AWS.Lambda;
   const lambdaOptions = {
@@ -21,6 +23,10 @@ async function lambdaInvocationAdapter (config) {
       connectTimeout: config.timeout,
       timeout: config.timeout
     };
+  } else {
+    lambdaOptions.httpOptions = {
+      timeout: LAMBDA_MAX_TIMEOUT,
+    }
   }
 
   const lambda = new Lambda(lambdaOptions);


### PR DESCRIPTION
The `Alpha` client is intended to treat calls to lambda in the same way that Axios treats HTTPS calls. That is, they should have the same behavior and the same defaults. By default, Axios has no timeout (https://stackoverflow.com/questions/57995863/what-is-axios-default-timeout), so technically Lambda calls should be treated the same. 

Previously, if `timeout` was not provided to this client, `lambdaOptions.httpOptions.timeout` was left unset. However, AWS documentation shows that the default lambda timeout is 3 seconds (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html):
> **Timeout** – The amount of time that Lambda allows a function to run before stopping it. The default is three seconds. The maximum allowed value is 900 seconds.

Obviously the lambda-instantiated `Alpha` client cannot match Axios by having _no_ timeout, so instead we use the maximum length of a lambda function, 15 minutes.