### PR TITLE
Upgrade axios to `0.21.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.184.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "docker-lambda": "^0.15.3",
     "lodash": "^4.17.20",
     "nearley": "^2.19.7",


### PR DESCRIPTION
There is a dependabot PR in forum-service to bump axios to `0.21.2`. This PR is failing unit tests for some reason. I am hoping that upgrading past `0.21.2` to the latest `0.21.4` resolves these issues. Unfortunately the type signatures for the latest version of axios and the version of axios included in `@lifeomic/alpha` don't match.

This PR bumps axios to the latest version.

See:
https://github.com/lifeomic/forum-service/pull/171
https://github.com/lifeomic/life-extend/pull/1690
https://github.com/axios/axios/issues/4036