### PR TITLE
Add requestContext as a lambda event property

### DIFF
--- a/.github/workflows/pr-branch-build.yaml
+++ b/.github/workflows/pr-branch-build.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Node.JS ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint .",
     "prepare": "yarn run transpile && yarn buildGrammar && cp src/Alpha.d.ts lib",
     "pretest": "yarn buildGrammar && yarn lint",
-    "test": "nyc ava",
+    "test": "nyc ava --verbose",
     "transpile": "babel src --out-dir lib"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.184.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "docker-lambda": "^0.15.3",
     "lodash": "^4.17.20",
     "nearley": "^2.19.7",

--- a/src/Alpha.d.ts
+++ b/src/Alpha.d.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosRequestConfig, AxiosStatic } from 'axios';
+import { AxiosInstance, AxiosPromise, AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios';
 export { AxiosResponse, AxiosError, AxiosPromise } from 'axios';
 import { SpawnSyncOptions } from 'child_process';
 
@@ -14,7 +14,27 @@ export interface AlphaOptions extends AxiosRequestConfig {
   lambda?: Function
 }
 
-export type AlphaInstance = AxiosInstance;
+export interface AlphaRequestConfig extends AxiosRequestConfig {
+  requestContext?: Record<string, any>;
+}
+
+export interface AlphaResponse<T> extends AxiosResponse<T> {
+  config: AlphaRequestConfig;
+}
+
+export interface AlphaInstance extends AxiosInstance{
+  <T = any, R = AlphaResponse<T>>(config: AlphaRequestConfig): Promise<R>;
+  <T = any, R = AlphaResponse<T>>(url: string, config?: AlphaRequestConfig): Promise<R>;
+  getUri(config?: AlphaRequestConfig): string;
+  request<T = any, R = AlphaResponse<T>> (config: AlphaRequestConfig): Promise<R>;
+  get<T = any, R = AlphaResponse<T>>(url: string, config?: AlphaRequestConfig): Promise<R>;
+  delete<T = any, R = AlphaResponse<T>>(url: string, config?: AlphaRequestConfig): Promise<R>;
+  head<T = any, R = AlphaResponse<T>>(url: string, config?: AlphaRequestConfig): Promise<R>;
+  options<T = any, R = AlphaResponse<T>>(url: string, config?: AlphaRequestConfig): Promise<R>;
+  post<T = any, R = AlphaResponse<T>>(url: string, data?: any, config?: AlphaRequestConfig): Promise<R>;
+  put<T = any, R = AlphaResponse<T>>(url: string, data?: any, config?: AlphaRequestConfig): Promise<R>;
+  patch<T = any, R = AlphaResponse<T>>(url: string, data?: any, config?: AlphaRequestConfig): Promise<R>;
+}
 
 export interface DockerLambdaOptions {
   dockerImage?: string;

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -11,7 +11,8 @@ module.exports = (config, relativeUrl) => {
     headers: config.headers,
     httpMethod: config.method.toUpperCase(),
     path: parts.pathname,
-    queryStringParameters: params
+    queryStringParameters: params,
+    requestContext: config.requestContext
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -27,7 +27,8 @@ test.serial(`Can parse URLs with duplicate parameters`, async (test) => {
         'http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3'
       ],
       pageSize: '25'
-    }
+    },
+    requestContext: undefined
   });
 });
 
@@ -42,7 +43,8 @@ test.serial(`Can parse URLs without duplicates`, async (test) => {
       _tag: 'http://lifeomic.com/fhir/questionnaire-type|survey-form',
       pageSize: '25',
       test: 'diffValue'
-    }
+    },
+    requestContext: undefined
   });
 });
 
@@ -56,7 +58,8 @@ test.serial(`handles null values`, test => {
     queryStringParameters: {
       pageSize: '25',
       onlyKey: ''
-    }
+    },
+    requestContext: undefined
   });
 });
 
@@ -70,6 +73,7 @@ test.serial(`handles null keys`, test => {
     queryStringParameters: {
       pageSize: '25',
       '': 'onlyvalue'
-    }
+    },
+    requestContext: undefined
   });
 });

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -35,7 +35,8 @@ test('works with a callback style handler that executes the callback async', asy
     headers: sinon.match.object,
     httpMethod: 'GET',
     path: '/some/path',
-    queryStringParameters: {}
+    queryStringParameters: {},
+    requestContext: undefined
   };
 
   const context = {};
@@ -80,7 +81,8 @@ function registerSpecs (isCallbackStyleHandler) {
       headers: sinon.match.object,
       httpMethod: 'GET',
       path: '/some/path',
-      queryStringParameters: {}
+      queryStringParameters: {},
+      requestContext: undefined
     };
 
     const context = {};
@@ -139,7 +141,7 @@ function registerSpecs (isCallbackStyleHandler) {
     test.is(result.data, response.body);
   });
 
-  test(`Redirects are automaticaly followed (301) (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+  test(`Redirects are automatically followed (301) (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
     const redirect = {
       headers: { location: '/other/path' },
       statusCode: 301
@@ -173,7 +175,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/some/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: undefined
       },
       {},
       sinon.match.func
@@ -185,7 +188,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/other/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: undefined
       },
       {},
       sinon.match.func
@@ -226,7 +230,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/some/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: undefined
       },
       {},
       sinon.match.func
@@ -238,7 +243,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/other/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: undefined
       },
       {},
       sinon.match.func
@@ -267,7 +273,8 @@ function registerSpecs (isCallbackStyleHandler) {
       httpMethod: 'PUT',
       isBase64Encoded: true,
       path: '/some/path',
-      queryStringParameters: {}
+      queryStringParameters: {},
+      requestContext: undefined
     };
 
     sinon.assert.calledWithExactly(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,10 +1335,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.21.1:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@^0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
 


### PR DESCRIPTION
![context](https://media.giphy.com/media/ZazzhhJxVUu5RLADVm/giphy.gif?cid=ecf05e47tadijfqrs912mngmj5mbrxrnmm7n2f202xeq8ico&rid=giphy.gif&ct=g)

When API Gateway creates a Lambda event it may also include a `requestContext` attribute.  We are using that in some projects to set the User, Account, Policy etc.  This makes It possible to set the attribute in the config for each request, and then is sent to Lambda.

https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-input.html
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference