### PR TITLE
Add requestContext to lambda event to support apollo-server-lambda

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "coverage": "nyc report --reporter=text-lcov > ./.nyc_output/lcov.info",
     "buildGrammar": "nearleyc src/adapters/helpers/lambdaURL.ne -o src/adapters/helpers/lambdaURLGrammar.js",
     "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "prepare": "yarn run transpile && yarn buildGrammar && cp src/Alpha.d.ts lib",
     "pretest": "yarn buildGrammar && yarn lint",
     "test": "nyc ava",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -3,7 +3,11 @@ const querystring = require('querystring');
 
 module.exports = (config, relativeUrl) => {
   // url-parse needs a location to properly handle relative urls, so provide a fake one here:
-  const parts = urlParse(relativeUrl || config.url, 'http://fake', querystringWithArraySupport);
+  const parts = urlParse(
+    relativeUrl || config.url,
+    'http://fake',
+    querystringWithArraySupport
+  );
   const params = Object.assign({}, parts.query, config.params);
 
   const event = {
@@ -11,7 +15,11 @@ module.exports = (config, relativeUrl) => {
     headers: config.headers,
     httpMethod: config.method.toUpperCase(),
     path: parts.pathname,
-    queryStringParameters: params
+    queryStringParameters: params,
+    requestContext: {
+      httpMethod: config.method.toUpperCase(),
+      resourcePath: parts.pathname
+    }
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -16,10 +16,7 @@ module.exports = (config, relativeUrl) => {
     httpMethod: config.method.toUpperCase(),
     path: parts.pathname,
     queryStringParameters: params,
-    requestContext: {
-      httpMethod: config.method.toUpperCase(),
-      resourcePath: parts.pathname
-    }
+    requestContext: {}
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -27,6 +27,10 @@ test.serial(`Can parse URLs with duplicate parameters`, async (test) => {
         'http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3'
       ],
       pageSize: '25'
+    },
+    requestContext: {
+      httpMethod: 'GET',
+      resourcePath: '/lifeomic/dstu3/Questionnaire'
     }
   });
 });
@@ -42,6 +46,10 @@ test.serial(`Can parse URLs without duplicates`, async (test) => {
       _tag: 'http://lifeomic.com/fhir/questionnaire-type|survey-form',
       pageSize: '25',
       test: 'diffValue'
+    },
+    requestContext: {
+      httpMethod: 'GET',
+      resourcePath: '/lifeomic/dstu3/Questionnaire'
     }
   });
 });
@@ -56,6 +64,10 @@ test.serial(`handles null values`, test => {
     queryStringParameters: {
       pageSize: '25',
       onlyKey: ''
+    },
+    requestContext: {
+      httpMethod: 'GET',
+      resourcePath: '/lifeomic/dstu3/Questionnaire'
     }
   });
 });
@@ -70,6 +82,10 @@ test.serial(`handles null keys`, test => {
     queryStringParameters: {
       pageSize: '25',
       '': 'onlyvalue'
+    },
+    requestContext: {
+      httpMethod: 'GET',
+      resourcePath: '/lifeomic/dstu3/Questionnaire'
     }
   });
 });

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -28,10 +28,7 @@ test.serial(`Can parse URLs with duplicate parameters`, async (test) => {
       ],
       pageSize: '25'
     },
-    requestContext: {
-      httpMethod: 'GET',
-      resourcePath: '/lifeomic/dstu3/Questionnaire'
-    }
+    requestContext: {}
   });
 });
 
@@ -47,10 +44,7 @@ test.serial(`Can parse URLs without duplicates`, async (test) => {
       pageSize: '25',
       test: 'diffValue'
     },
-    requestContext: {
-      httpMethod: 'GET',
-      resourcePath: '/lifeomic/dstu3/Questionnaire'
-    }
+    requestContext: {}
   });
 });
 
@@ -65,10 +59,7 @@ test.serial(`handles null values`, test => {
       pageSize: '25',
       onlyKey: ''
     },
-    requestContext: {
-      httpMethod: 'GET',
-      resourcePath: '/lifeomic/dstu3/Questionnaire'
-    }
+    requestContext: {}
   });
 });
 
@@ -83,9 +74,6 @@ test.serial(`handles null keys`, test => {
       pageSize: '25',
       '': 'onlyvalue'
     },
-    requestContext: {
-      httpMethod: 'GET',
-      resourcePath: '/lifeomic/dstu3/Questionnaire'
-    }
+    requestContext: {}
   });
 });

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -36,7 +36,7 @@ test('works with a callback style handler that executes the callback async', asy
     httpMethod: 'GET',
     path: '/some/path',
     queryStringParameters: {},
-    requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
+    requestContext: {}
   };
 
   const context = {};
@@ -82,7 +82,7 @@ function registerSpecs (isCallbackStyleHandler) {
       httpMethod: 'GET',
       path: '/some/path',
       queryStringParameters: {},
-      requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
+      requestContext: {}
     };
 
     const context = {};
@@ -176,7 +176,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -189,7 +189,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: { httpMethod: 'GET', resourcePath: '/other/path' }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -231,7 +231,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -244,7 +244,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: { httpMethod: 'GET', resourcePath: '/other/path' }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -274,7 +274,7 @@ function registerSpecs (isCallbackStyleHandler) {
       isBase64Encoded: true,
       path: '/some/path',
       queryStringParameters: {},
-      requestContext: { httpMethod: 'PUT', resourcePath: '/some/path' }
+      requestContext: {}
     };
 
     sinon.assert.calledWithExactly(

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -35,7 +35,8 @@ test('works with a callback style handler that executes the callback async', asy
     headers: sinon.match.object,
     httpMethod: 'GET',
     path: '/some/path',
-    queryStringParameters: {}
+    queryStringParameters: {},
+    requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
   };
 
   const context = {};
@@ -80,7 +81,8 @@ function registerSpecs (isCallbackStyleHandler) {
       headers: sinon.match.object,
       httpMethod: 'GET',
       path: '/some/path',
-      queryStringParameters: {}
+      queryStringParameters: {},
+      requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
     };
 
     const context = {};
@@ -173,7 +175,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/some/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
       },
       {},
       sinon.match.func
@@ -185,7 +188,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/other/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: { httpMethod: 'GET', resourcePath: '/other/path' }
       },
       {},
       sinon.match.func
@@ -226,7 +230,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/some/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: { httpMethod: 'GET', resourcePath: '/some/path' }
       },
       {},
       sinon.match.func
@@ -238,7 +243,8 @@ function registerSpecs (isCallbackStyleHandler) {
         headers: sinon.match.object,
         httpMethod: 'GET',
         path: '/other/path',
-        queryStringParameters: {}
+        queryStringParameters: {},
+        requestContext: { httpMethod: 'GET', resourcePath: '/other/path' }
       },
       {},
       sinon.match.func
@@ -267,7 +273,8 @@ function registerSpecs (isCallbackStyleHandler) {
       httpMethod: 'PUT',
       isBase64Encoded: true,
       path: '/some/path',
-      queryStringParameters: {}
+      queryStringParameters: {},
+      requestContext: { httpMethod: 'PUT', resourcePath: '/some/path' }
     };
 
     sinon.assert.calledWithExactly(


### PR DESCRIPTION
This is an attempt to fix a bug when invoking a handler created with `apollo-server-lambda` v3. 

`apollo-server-lambda` v3 uses `@vendia/serverless-express` under the hood which expects a requestContext field on the lambda event or else it fails to determine the event source.

https://github.com/vendia/serverless-express/issues/416