### PR TITLE
Add multiValueHeaders field to API Gateway event.

### DIFF
--- a/.github/workflows/pr-branch-build.yaml
+++ b/.github/workflows/pr-branch-build.yaml
@@ -28,26 +28,6 @@ jobs:
           path-to-lcov: .nyc_output/lcov.info
           flag-name: run-${{ matrix.node }}
           parallel: true
-  preRelease:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org
-      - name: Install
-        run: yarn install --frozen-lockfile
-      - name: Version
-        env:
-          PRE_ID: pr-${{ github.event.number }}-${{ github.run_id }}
-        run: npm version prepatch --git-tag-version=false --preid="${PRE_ID}-$(date '+%s')"
-      - name: PrePublish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.LIFEOMIC_NPM_TOKEN}}
-          PR_TAG: pr-${{ github.event.number }}
-        run: npm publish --tag "${PR_TAG}"
   finish:
     needs: test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The `lambda` URL scheme is interpreted according to the following pattern:
 #### Lambda Handler Targets
 
 When an `Alpha` instance is created with a handler function target, requests to
-unqualified URLs will be transformed into synthetic [API Gateway][api-gateway]
+unqualified URLs will be transformed into synthetic [API Gateway (v1)][api-gateway]
 events that will be passed directly to the handler function. This is primarily
 used for unit testing Lambda handlers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -1,6 +1,5 @@
 const urlParse = require('url-parse');
 const querystring = require('querystring');
-const isEmpty = require('lodash/isEmpty');
 
 module.exports = (config, relativeUrl) => {
   // url-parse needs a location to properly handle relative urls, so provide a fake one here:
@@ -22,27 +21,14 @@ module.exports = (config, relativeUrl) => {
     httpMethod: config.method.toUpperCase(),
     path: parts.pathname,
     queryStringParameters: params,
-    requestContext: {}
+    requestContext: {},
+    /**
+     * Copy headers into multiValueHeaders.
+     * Needed for invoking @vendia/serverless-express handlers.
+     * https://github.com/apollographql/apollo-server/issues/5504
+     */
+    multiValueHeaders: config.headers
   };
-
-  /**
-   * Add content-type to multiValueHeaders.
-   * Needed for invoking @vendia/serverless-express handlers.
-   * https://github.com/apollographql/apollo-server/issues/5504
-   */
-  const multiValueHeaders = Object.entries({ ...config.headers }).reduce((prev, [name, value]) => {
-    if (name.toLocaleLowerCase() === 'content-type') {
-      return {
-        ...prev,
-        'Content-Type': value
-      };
-    }
-    return prev;
-  }, {});
-
-  if (!isEmpty(multiValueHeaders)) {
-    event.multiValueHeaders = multiValueHeaders;
-  }
 
   if (Buffer.isBuffer(event.body)) {
     event.body = event.body.toString('base64');

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -27,7 +27,13 @@ module.exports = (config, relativeUrl) => {
      * Needed for invoking @vendia/serverless-express handlers.
      * https://github.com/apollographql/apollo-server/issues/5504
      */
-    multiValueHeaders: config.headers
+    multiValueHeaders: Object.entries({ ...config.headers }).reduce((prev, [name, value]) => {
+      const values = value.split(',').map((v) => v.trim());
+      return {
+        ...prev,
+        [name]: values
+      };
+    }, {})
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -30,7 +30,7 @@ module.exports = (config, relativeUrl) => {
    * Needed for invoking @vendia/serverless-express handlers.
    * https://github.com/apollographql/apollo-server/issues/5504
    */
-  const multiValueHeaders = Object.entries(config.headers).reduce((prev, [name, value]) => {
+  const multiValueHeaders = Object.entries({ ...config.headers }).reduce((prev, [name, value]) => {
     if (name.toLocaleLowerCase() === 'content-type') {
       return {
         ...prev,

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -10,13 +10,23 @@ module.exports = (config, relativeUrl) => {
   );
   const params = Object.assign({}, parts.query, config.params);
 
+  /**
+   * A mock API Gateway v1 proxy event.
+   * See here for more info: https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#apigateway-example-event
+   * The APIGatewayProxyEvent type can be imported from the aws-lambda npm package.
+   */
   const event = {
     body: config.data || '',
     headers: config.headers,
     httpMethod: config.method.toUpperCase(),
     path: parts.pathname,
     queryStringParameters: params,
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {
+      // Needed for invoking apollo-server-lambda handlers.
+      // https://github.com/apollographql/apollo-server/issues/5504
+      'Content-Type': 'application/json'
+    }
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -29,7 +29,8 @@ test.serial(`Can parse URLs with duplicate parameters`, async (test) => {
       ],
       pageSize: '25'
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {}
   });
 });
 
@@ -45,7 +46,8 @@ test.serial(`Can parse URLs without duplicates`, async (test) => {
       pageSize: '25',
       test: 'diffValue'
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {}
   });
 });
 
@@ -60,7 +62,8 @@ test.serial(`handles null values`, test => {
       pageSize: '25',
       onlyKey: ''
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {}
   });
 });
 
@@ -75,7 +78,8 @@ test.serial(`handles null keys`, test => {
       pageSize: '25',
       '': 'onlyvalue'
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {}
   });
 });
 
@@ -83,12 +87,12 @@ test.serial(`Adds content-type to multiValueHeaders`, test => {
   const config = {
     data: JSON.stringify({ data: 'test' }),
     method: 'POST',
-    headers: { 'content-type': 'application/json', 'test': 'test' },
+    headers: { 'Content-Type': 'application/json' },
     url: lambda + noParams
   };
   test.deepEqual(lambdaEvent(config, noParams), {
     body: JSON.stringify({ data: 'test' }),
-    headers: { 'content-type': 'application/json', 'test': 'test' },
+    headers: { 'Content-Type': 'application/json' },
     httpMethod: 'POST',
     path: '/lifeomic/dstu3/Questionnaire',
     queryStringParameters: {},

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -5,6 +5,7 @@ const duplicateParams = '/lifeomic/dstu3/Questionnaire?pageSize=25&_tag=http%3A%
 const params = '/lifeomic/dstu3/Questionnaire?pageSize=25&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fquestionnaire-type%7Csurvey-form&test=diffValue';
 const invalidValueParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&=onlyvalue';
 const invalidKeyParam = '/lifeomic/dstu3/Questionnaire?pageSize=25&onlyKey=';
+const noParams = '/lifeomic/dstu3/Questionnaire';
 
 const lambda = `lambda://service:deployed/`;
 const config = {
@@ -28,10 +29,7 @@ test.serial(`Can parse URLs with duplicate parameters`, async (test) => {
       ],
       pageSize: '25'
     },
-    requestContext: {},
-    multiValueHeaders: {
-      'Content-Type': 'application/json'
-    }
+    requestContext: {}
   });
 });
 
@@ -47,10 +45,7 @@ test.serial(`Can parse URLs without duplicates`, async (test) => {
       pageSize: '25',
       test: 'diffValue'
     },
-    requestContext: {},
-    multiValueHeaders: {
-      'Content-Type': 'application/json'
-    }
+    requestContext: {}
   });
 });
 
@@ -65,10 +60,7 @@ test.serial(`handles null values`, test => {
       pageSize: '25',
       onlyKey: ''
     },
-    requestContext: {},
-    multiValueHeaders: {
-      'Content-Type': 'application/json'
-    }
+    requestContext: {}
   });
 });
 
@@ -83,6 +75,23 @@ test.serial(`handles null keys`, test => {
       pageSize: '25',
       '': 'onlyvalue'
     },
+    requestContext: {}
+  });
+});
+
+test.serial(`Adds content-type to multiValueHeaders`, test => {
+  const config = {
+    data: JSON.stringify({ data: 'test' }),
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'test': 'test' },
+    url: lambda + noParams
+  };
+  test.deepEqual(lambdaEvent(config, noParams), {
+    body: JSON.stringify({ data: 'test' }),
+    headers: { 'content-type': 'application/json', 'test': 'test' },
+    httpMethod: 'POST',
+    path: '/lifeomic/dstu3/Questionnaire',
+    queryStringParameters: {},
     requestContext: {},
     multiValueHeaders: {
       'Content-Type': 'application/json'

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -98,7 +98,7 @@ test.serial(`Adds content-type to multiValueHeaders`, test => {
     queryStringParameters: {},
     requestContext: {},
     multiValueHeaders: {
-      'Content-Type': 'application/json'
+      'Content-Type': ['application/json']
     }
   });
 });

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -28,7 +28,10 @@ test.serial(`Can parse URLs with duplicate parameters`, async (test) => {
       ],
       pageSize: '25'
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {
+      'Content-Type': 'application/json'
+    }
   });
 });
 
@@ -44,7 +47,10 @@ test.serial(`Can parse URLs without duplicates`, async (test) => {
       pageSize: '25',
       test: 'diffValue'
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {
+      'Content-Type': 'application/json'
+    }
   });
 });
 
@@ -59,7 +65,10 @@ test.serial(`handles null values`, test => {
       pageSize: '25',
       onlyKey: ''
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {
+      'Content-Type': 'application/json'
+    }
   });
 });
 
@@ -74,6 +83,9 @@ test.serial(`handles null keys`, test => {
       pageSize: '25',
       '': 'onlyvalue'
     },
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {
+      'Content-Type': 'application/json'
+    }
   });
 });

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -36,7 +36,10 @@ test('works with a callback style handler that executes the callback async', asy
     httpMethod: 'GET',
     path: '/some/path',
     queryStringParameters: {},
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: {
+      'Content-Type': 'application/json'
+    }
   };
 
   const context = {};
@@ -82,7 +85,10 @@ function registerSpecs (isCallbackStyleHandler) {
       httpMethod: 'GET',
       path: '/some/path',
       queryStringParameters: {},
-      requestContext: {}
+      requestContext: {},
+      multiValueHeaders: {
+        'Content-Type': 'application/json'
+      }
     };
 
     const context = {};
@@ -176,7 +182,10 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: {
+          'Content-Type': 'application/json'
+        }
       },
       {},
       sinon.match.func
@@ -189,7 +198,10 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: {
+          'Content-Type': 'application/json'
+        }
       },
       {},
       sinon.match.func
@@ -231,7 +243,10 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: {
+          'Content-Type': 'application/json'
+        }
       },
       {},
       sinon.match.func
@@ -244,7 +259,10 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: {
+          'Content-Type': 'application/json'
+        }
       },
       {},
       sinon.match.func
@@ -274,7 +292,10 @@ function registerSpecs (isCallbackStyleHandler) {
       isBase64Encoded: true,
       path: '/some/path',
       queryStringParameters: {},
-      requestContext: {}
+      requestContext: {},
+      multiValueHeaders: {
+        'Content-Type': 'application/json'
+      }
     };
 
     sinon.assert.calledWithExactly(

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -36,10 +36,7 @@ test('works with a callback style handler that executes the callback async', asy
     httpMethod: 'GET',
     path: '/some/path',
     queryStringParameters: {},
-    requestContext: {},
-    multiValueHeaders: {
-      'Content-Type': 'application/json'
-    }
+    requestContext: {}
   };
 
   const context = {};
@@ -83,6 +80,50 @@ function registerSpecs (isCallbackStyleHandler) {
       body: '',
       headers: sinon.match.object,
       httpMethod: 'GET',
+      path: '/some/path',
+      queryStringParameters: {},
+      requestContext: {}
+    };
+
+    const context = {};
+
+    sinon.assert.calledWithExactly(
+      test.context.handler,
+      event,
+      context,
+      sinon.match.func
+    );
+  });
+
+  test(`Making a POST request to a local handler invokes the handler (callbackStyle=${isCallbackStyleHandler})`, async (test) => {
+    const response = {
+      headers: { 'test-header': 'some value' },
+      body: {
+        hello: 'hello'
+      },
+      statusCode: 200
+    };
+
+    setupHandlerBehavior({
+      handlerStub: test.context.handler,
+      isCallbackStyleHandler,
+      response
+    });
+    const result = await test.context.client.post('/some/path', { data: 'test' }, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer test'
+      }
+    });
+
+    test.is(result.status, 200);
+    test.deepEqual(result.headers, response.headers);
+    test.is(result.data, response.body);
+
+    const event = {
+      body: JSON.stringify({ data: 'test' }),
+      headers: sinon.match.object,
+      httpMethod: 'POST',
       path: '/some/path',
       queryStringParameters: {},
       requestContext: {},
@@ -182,10 +223,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {},
-        multiValueHeaders: {
-          'Content-Type': 'application/json'
-        }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -198,10 +236,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {},
-        multiValueHeaders: {
-          'Content-Type': 'application/json'
-        }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -243,10 +278,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {},
-        multiValueHeaders: {
-          'Content-Type': 'application/json'
-        }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -259,10 +291,7 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {},
-        multiValueHeaders: {
-          'Content-Type': 'application/json'
-        }
+        requestContext: {}
       },
       {},
       sinon.match.func
@@ -293,9 +322,7 @@ function registerSpecs (isCallbackStyleHandler) {
       path: '/some/path',
       queryStringParameters: {},
       requestContext: {},
-      multiValueHeaders: {
-        'Content-Type': 'application/json'
-      }
+      multiValueHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' }
     };
 
     sinon.assert.calledWithExactly(

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -36,7 +36,8 @@ test('works with a callback style handler that executes the callback async', asy
     httpMethod: 'GET',
     path: '/some/path',
     queryStringParameters: {},
-    requestContext: {}
+    requestContext: {},
+    multiValueHeaders: sinon.match.object
   };
 
   const context = {};
@@ -82,7 +83,8 @@ function registerSpecs (isCallbackStyleHandler) {
       httpMethod: 'GET',
       path: '/some/path',
       queryStringParameters: {},
-      requestContext: {}
+      requestContext: {},
+      multiValueHeaders: sinon.match.object
     };
 
     const context = {};
@@ -111,8 +113,7 @@ function registerSpecs (isCallbackStyleHandler) {
     });
     const result = await test.context.client.post('/some/path', { data: 'test' }, {
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer test'
+        'Content-Type': 'application/json'
       }
     });
 
@@ -127,9 +128,7 @@ function registerSpecs (isCallbackStyleHandler) {
       path: '/some/path',
       queryStringParameters: {},
       requestContext: {},
-      multiValueHeaders: {
-        'Content-Type': 'application/json'
-      }
+      multiValueHeaders: sinon.match.object
     };
 
     const context = {};
@@ -223,7 +222,8 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: sinon.match.object
       },
       {},
       sinon.match.func
@@ -236,7 +236,8 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: sinon.match.object
       },
       {},
       sinon.match.func
@@ -278,7 +279,8 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: sinon.match.object
       },
       {},
       sinon.match.func
@@ -291,7 +293,8 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {},
+        multiValueHeaders: sinon.match.object
       },
       {},
       sinon.match.func
@@ -322,7 +325,7 @@ function registerSpecs (isCallbackStyleHandler) {
       path: '/some/path',
       queryStringParameters: {},
       requestContext: {},
-      multiValueHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      multiValueHeaders: sinon.match.object
     };
 
     sinon.assert.calledWithExactly(


### PR DESCRIPTION
This adds one more thing to make `alpha.post(handler)` requests work with `apollo-server-lambda` v3 handlers.

