### PR TITLE
Generate a random request ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "lodash": "^4.17.21",
     "nearley": "2",
     "resolve-pathname": "^3.0.0",
-    "url-parse": "^1.5.3"
+    "url-parse": "^1.5.3",
+    "uuid": "^8.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/src/adapters/helpers/lambdaEvent.js
+++ b/src/adapters/helpers/lambdaEvent.js
@@ -1,5 +1,6 @@
 const urlParse = require('url-parse');
 const querystring = require('querystring');
+const { v4: uuid } = require('uuid');
 
 module.exports = (config, relativeUrl) => {
   // url-parse needs a location to properly handle relative urls, so provide a fake one here:
@@ -16,7 +17,9 @@ module.exports = (config, relativeUrl) => {
     httpMethod: config.method.toUpperCase(),
     path: parts.pathname,
     queryStringParameters: params,
-    requestContext: {}
+    requestContext: {
+      requestId: uuid()
+    }
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/test/lambda-handler.test.js
+++ b/test/lambda-handler.test.js
@@ -36,7 +36,9 @@ test('works with a callback style handler that executes the callback async', asy
     httpMethod: 'GET',
     path: '/some/path',
     queryStringParameters: {},
-    requestContext: {}
+    requestContext: {
+      requestId: sinon.match.string
+    }
   };
 
   const context = {};
@@ -82,7 +84,9 @@ function registerSpecs (isCallbackStyleHandler) {
       httpMethod: 'GET',
       path: '/some/path',
       queryStringParameters: {},
-      requestContext: {}
+      requestContext: {
+        requestId: sinon.match.string
+      }
     };
 
     const context = {};
@@ -176,7 +180,9 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {
+          requestId: sinon.match.string
+        }
       },
       {},
       sinon.match.func
@@ -189,7 +195,9 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {
+          requestId: sinon.match.string
+        }
       },
       {},
       sinon.match.func
@@ -231,7 +239,9 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/some/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {
+          requestId: sinon.match.string
+        }
       },
       {},
       sinon.match.func
@@ -244,7 +254,9 @@ function registerSpecs (isCallbackStyleHandler) {
         httpMethod: 'GET',
         path: '/other/path',
         queryStringParameters: {},
-        requestContext: {}
+        requestContext: {
+          requestId: sinon.match.string
+        }
       },
       {},
       sinon.match.func
@@ -274,7 +286,9 @@ function registerSpecs (isCallbackStyleHandler) {
       isBase64Encoded: true,
       path: '/some/path',
       queryStringParameters: {},
-      requestContext: {}
+      requestContext: {
+        requestId: sinon.match.string
+      }
     };
 
     sinon.assert.calledWithExactly(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5798,6 +5798,11 @@ uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
The LifeOmic request processing uses the request ID attribute from
the APIG event payload as the default value for correlation IDs.
When an Alpha request is the root event in a tree of requests this
means that there is no correlation ID generated for the entire
tree.

Generating a request ID on Alpha requests will allow the LO
machinery to infer and propagate an correlation ID when Alpha is
the originator of the request.