### PR TITLE
Add config option for the aws lambda endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ const alpha = new Alpha('http://example.com', { retry: {
 
 #### Mocking Lambda
 
-To redirect the Lambda requests to a mocked implementation, set the
-`LAMBDA_ENDPOINT` environment variable.  The value of this environment variable
-will be used when creating the AWS Lambda client.
+To redirect the Lambda requests to a mocked implementation, either set the
+`LAMBDA_ENDPOINT` environment variable, or use the `lambdaEndpoint` config option:
+
+```javascript
+const alpha = new Alpha('lambda:my-lambda', { 
+  lambdaEndpoint: 'http://localstack:4566'
+});
+```
+
+The value of this option will be used when creating the AWS Lambda client.
 
 ### `Alpha.dockerLambda(options, clientOptions)`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Unified client for HTTP services.",
   "main": "lib/Alpha",
   "types": "lib/Alpha.d.ts",

--- a/src/Alpha.d.ts
+++ b/src/Alpha.d.ts
@@ -11,7 +11,11 @@ interface RetryOptions {
 
 export interface AlphaOptions extends AxiosRequestConfig {
   retry?: RetryOptions,
-  lambda?: Function
+  lambda?: Function,
+  /**
+   * (Optional) The AWS endpoint to use when invoking the target Lambda function.
+   */
+  lambdaEndpoint?: string;
 }
 
 export type AlphaInstance = AxiosInstance;

--- a/src/adapters/lambda-invocation.js
+++ b/src/adapters/lambda-invocation.js
@@ -10,7 +10,7 @@ const RequestError = require('./helpers/RequestError');
 async function lambdaInvocationAdapter (config) {
   const Lambda = config.Lambda || AWS.Lambda;
   const lambdaOptions = {
-    endpoint: process.env.LAMBDA_ENDPOINT
+    endpoint: config.lambdaEndpoint || process.env.LAMBDA_ENDPOINT
   };
 
   if (config.timeout) {

--- a/test/lambda-invocation.test.js
+++ b/test/lambda-invocation.test.js
@@ -537,3 +537,24 @@ test.serial('lambda function invocation errors are re-thrown', async (test) => {
 
   test.is(error.message, 'Other error');
 });
+
+test.serial('lambdaEndpoint config option is provided to the Lambda client', async (test) => {
+  const alpha = new Alpha('lambda://test-function', {
+    lambdaEndpoint: 'http://test-endpoint'
+  });
+
+  test.context.invoke.callsArgWith(1, null, {
+    StatusCode: 200,
+    Payload: JSON.stringify({
+      body: 'test',
+      statusCode: 200
+    })
+  });
+
+  const response = await alpha.get('/test');
+
+  test.is(response.data, 'test');
+  test.is(response.status, 200);
+
+  sinon.assert.calledWith(AWS_SDK.Lambda, { endpoint: 'http://test-endpoint' });
+});


### PR DESCRIPTION
Currently the only way to choose the lambda endpoint is with the `LAMBDA_ENDPOINT` env var. This works fine when you only have a single endpoint, but fails when you have multiple endpoints. With this change you can invoke multiple dockerized lambdas hosted at different endpoints using the `lambdaEndpoint` config option.