### PR TITLE
feat: expose types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { resolve } from './resolve';
 export { Alpha } from './alpha';
+export * from './types'
 export { isAlphaRequestError, isAxiosError } from './adapters/helpers/requestError';


### PR DESCRIPTION
## Motivation
In particular, `AlphaOptions` was lost in the v4 TypeScript re-write. Just re-adding some root-level exports here.