### PR TITLE
chore: use npmrc auth instead

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,4 +22,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.LIFEOMIC_NPM_TOKEN }}
-        run: yarn semantic-release
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          yarn semantic-release


### PR DESCRIPTION
## Motivation
If there's one thing `semantic-release` is not good at, it's authenticating to NPM.