### PR TITLE
fix: Adding response to request error

### DIFF
--- a/src/adapters/lambda-handler.ts
+++ b/src/adapters/lambda-handler.ts
@@ -39,7 +39,7 @@ const lambdaHandlerAdapter: AlphaAdapter = async (config) => {
     const result = await handler(request.event, request.context as Context) as Payload;
     return lambdaResponse(config, request, result);
   } catch (error: any | Error) {
-    throw new RequestError(error.message as string, config, request);
+    throw new RequestError(error.message as string, config, request, error.response);
   }
 };
 

--- a/src/adapters/lambda-handler.ts
+++ b/src/adapters/lambda-handler.ts
@@ -8,6 +8,7 @@ import { AlphaOptions, AlphaAdapter, HandlerRequest } from '../types';
 import { v4 as uuid } from 'uuid';
 import { Context, Handler } from 'aws-lambda';
 import { Alpha } from '../alpha';
+import { AxiosResponse } from 'axios';
 
 const createContext = (provided?: Partial<Context>): Context => {
   const defaultCtx: Context = {
@@ -39,7 +40,7 @@ const lambdaHandlerAdapter: AlphaAdapter = async (config) => {
     const result = await handler(request.event, request.context as Context) as Payload;
     return lambdaResponse(config, request, result);
   } catch (error: any | Error) {
-    throw new RequestError(error.message as string, config, request, error.response);
+    throw new RequestError(error.message as string, config, request, error.response as AxiosResponse);
   }
 };
 

--- a/test/lambda-handler.test.ts
+++ b/test/lambda-handler.test.ts
@@ -334,6 +334,29 @@ const registerSpecs = (isCallbackStyleHandler: boolean) => {
 
     expect(ctx.handler).toBeCalledWith(expect.objectContaining(event), expect.any(Object), expect.any(Function));
   });
+
+  test(`When a local handler returns an error the request fails with a response (callbackStyle=${isCallbackStyleHandler})`, async () => {
+    const failure = new Error('simulated failure');
+    const failureResponse = {
+      status: 400,
+      data: {
+        error: 'simulated failure response',
+      },
+    };
+    (failure as any).response = failureResponse;
+
+    setupHandlerBehavior({
+      handlerStub: ctx.handler,
+      error: failure,
+      isCallbackStyleHandler,
+    });
+
+    const promise = ctx.client.get('/some/path');
+    await expect(promise).rejects.toThrow(failure.message);
+    const error = await promise.catch((error) => error);
+
+    expect(error.response).toBe(failureResponse);
+  });
 };
 
 registerSpecs(true);


### PR DESCRIPTION
## Changes

- Added error response when throwing request error
- Added unit test

I noticed when updating lambda-tools along with alpha for integration tests within content service that some of our integration tests failed because response was undefined. I did some digging and that led me here.

<img width="634" alt="Screen Shot 2022-10-03 at 2 37 55 PM" src="https://user-images.githubusercontent.com/1435784/193590919-bfa4acdf-e2b3-4703-a5c6-deec4d44d2ca.png">
