### PR TITLE
fix: Need to call destroy to cleanup after creation

### DIFF
--- a/src/adapters/lambda-invocation.ts
+++ b/src/adapters/lambda-invocation.ts
@@ -79,6 +79,7 @@ const lambdaInvocationAdapter: AlphaAdapter = async (config) => {
       reject(error);
     });
   });
+  lambda.destroy();
 
   const payload = result.Payload && JSON.parse(Buffer.from(result.Payload).toString('utf-8')) as Payload | undefined;
   if (!payload) {


### PR DESCRIPTION
![protractor](https://media.giphy.com/media/gWyhZM3XKcyaI/giphy-downsized.gif)

Running without the destroy leaves open sockets between invocations.  The notes advise to call destroy to avoid long running sockets.  Through my testing just calling ListFunctions we end up with 2 open sockets up to 100, then an additional socket with every invocation.  Not sure how long the sockets are left open.