### PR TITLE
feat: declare axios as a production dependency

### DIFF
--- a/.github/workflows/pr-branch-build.yaml
+++ b/.github/workflows/pr-branch-build.yaml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        axios-version: [0.24.0, 0.25.0, 0.26.1, 0.27.2]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
@@ -18,5 +17,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - run: yarn install
-      - run: yarn add -D axios@${{ matrix.axios-version }}
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/url-parse": "^1.4.8",
     "@types/uuid": "^8.3.4",
     "aws-sdk-client-mock": "^1.0.0",
-    "axios": "^0.27.2",
     "conventional-changelog-conventionalcommits": "^4.0.0",
     "coveralls": "^3.1.0",
     "eslint": "^8.18.0",
@@ -61,13 +60,11 @@
     "@aws-sdk/signature-v4": "^3.110.0",
     "@aws-sdk/url-parser": "^3.357.0",
     "@types/aws-lambda": "^8.10.101",
+    "axios": "^0.27.2",
     "lodash": "^4.17.21",
     "nearley": "2",
     "url-parse": "^1.5.10",
     "uuid": "^8.3.2"
-  },
-  "peerDependencies": {
-    "axios": "0.24.x || 0.25.x || 0.26.x || 0.27.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This declares `axios` as a production dependency, rather than a `peerDependency`.

## Motivation
This PR aims to address a few consistent pain points I've experienced as a result of using `axios` as a peer dependency here.

**Current Problems**
- It is painful to need to maintain `alpha` typedefs that are compatible with _multiple_ versions of `axios`.

- Currently, any developer who wants to make us of both `alpha` _and_ `axios` directly within a single project _must_ only use a version of `axios` that `alpha` supports.

- Currently, the versions of `axios` that `alpha` supports are a long way behind the latest `axios` versions. And, the latest versions of `axios` are _incompatible_ with the current version of `alpha` -- so it is not as simple as e.g. `yarn add axios @lifeomic/alpha`. Rather, as a developer, you must install an _old_ version of `axios` in order for `alpha` to work.

**Solution**
This change will alleviate all of the above problems:

- We'll only need to maintain support for _one_ version of `axios` at a time (and can also reduce our CI cost as a result).

- Developers can now use `alpha` _and_ their `axios` version of choice, in the same project.

- Developers don't need to think about matching the peer dependency. Installation simplifies from `yarn add axios@^0.27.2 @lifeomic/alpha` to just `yarn add @lifeomic/alpha`.