### PR TITLE
chore: support alpha releases

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ['master'],
+  branches: ['master', { name: 'alpha', prerelease: true }],
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
     '@semantic-release/npm',


### PR DESCRIPTION
# Motivation

Adding support for publishing alpha pre-releases. I plan to add one with axios set to 0.28 so upstream consumers can safely resolve security updates.