### PR TITLE
fix: include method and url in request error message

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "arrowParens": "always",
+  "trailingComma": "all",
+  "singleQuote": true
+}

--- a/src/adapters/helpers/lambdaResponse.ts
+++ b/src/adapters/helpers/lambdaResponse.ts
@@ -18,8 +18,12 @@ const payloadToData = (config: AlphaOptions, payload: Payload) => {
   if (!config.responseType) return payload.body;
 
   switch (config.responseType) {
-    case 'arraybuffer': return new TextEncoder().encode(payload.body);
-    default: throw new Error('Unhandled responseType requested: ' + config.responseType);
+    case 'arraybuffer':
+      return new TextEncoder().encode(payload.body);
+    default:
+      throw new Error(
+        'Unhandled responseType requested: ' + config.responseType,
+      );
   }
 };
 
@@ -39,8 +43,18 @@ export const lambdaResponse = (
     statusText: http.STATUS_CODES[payload.statusCode] as string,
   };
 
-  if (typeof config.validateStatus === 'function' && !config.validateStatus(response.status)) {
-    throw new RequestError(`Request failed with status code ${response.status}`, config, request, response);
+  if (
+    typeof config.validateStatus === 'function' &&
+    !config.validateStatus(response.status)
+  ) {
+    throw new RequestError(
+      `Request${config.method ? ' ' + config.method.toUpperCase() : ''} ${
+        config.url
+      } failed with status code ${response.status}`,
+      config,
+      request,
+      response,
+    );
   }
 
   return response;


### PR DESCRIPTION
Sometimes I see errors like this in logs:
```
"Error: Request failed with status code 404
    at lambdaResponse (/node_modules/@lifeomic/alpha/lib/adapters/helpers/lambdaResponse.js:17:11)
    at <anonymous> (/node_modules/@lifeomic/alpha/lib/adapters/lambda-invocation.js:87:12)
```
These^ error messages don't give any info about which line threw the error, or what Lambda URL was being called. This change will make that error message look like `Error: Request GET lambda://test-function/some/path failed with status code 400`, which provides more helpful debug information.