### PR TITLE
fix: multiValueQueryStringParameters should be null if empty

### DIFF
--- a/src/adapters/helpers/lambdaEvent.ts
+++ b/src/adapters/helpers/lambdaEvent.ts
@@ -13,16 +13,18 @@ export const lambdaEvent = (config: AlphaOptions, relativeUrl?: string) => {
     'http://fake',
     querystringWithArraySupport,
   );
-  const params = Object.assign({}, parts.query, config.params);
-  const multiValueQueryStringParameters: Record<string, any> = { ...params };
+  const params: Record<string, any> = Object.assign({}, parts.query, config.params);
+  let multiValueParams: Record<string, any[]> | null = null;
 
-  Object.keys(multiValueQueryStringParameters).forEach((key) => {
-    if (!Array.isArray(multiValueQueryStringParameters[key])) {
-      delete multiValueQueryStringParameters[key];
-    } else {
-      delete params[key];
-    }
-  });
+  const hasMultiValueParams = Object.values(params).some((value) => Array.isArray(value));
+
+  if (hasMultiValueParams) {
+    Object.entries(params).forEach(([key, value]) => {
+      multiValueParams = multiValueParams || {};
+      multiValueParams[key] = Array.isArray(value) ? value : [value];
+      params[key] = Array.isArray(value) ? value.join(',') : value;
+    });
+  }
 
   const httpMethod = (config.method as string).toUpperCase();
   const requestTime = new Date();
@@ -73,10 +75,7 @@ export const lambdaEvent = (config: AlphaOptions, relativeUrl?: string) => {
         userArn: null,
       },
     },
-    multiValueQueryStringParameters:
-      Object.keys(multiValueQueryStringParameters).length > 0
-        ? multiValueQueryStringParameters
-        : null,
+    multiValueQueryStringParameters: multiValueParams,
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/src/adapters/helpers/lambdaEvent.ts
+++ b/src/adapters/helpers/lambdaEvent.ts
@@ -73,7 +73,10 @@ export const lambdaEvent = (config: AlphaOptions, relativeUrl?: string) => {
         userArn: null,
       },
     },
-    multiValueQueryStringParameters,
+    multiValueQueryStringParameters:
+      Object.keys(multiValueQueryStringParameters).length > 0
+        ? multiValueQueryStringParameters
+        : null,
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -31,6 +31,7 @@ test('Can parse URLs with duplicate parameters', () => {
     httpMethod: 'GET',
     path: '/lifeomic/dstu3/Questionnaire',
     queryStringParameters: {
+      _tag: 'http://lifeomic.com/fhir/questionnaire-type|survey-form,http://lifeomic.com/fhir/dataset|0bb18fef-4e2d-4b91-a623-09527265a8b3,http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3',
       pageSize: '25',
     },
     multiValueQueryStringParameters: {
@@ -39,6 +40,7 @@ test('Can parse URLs with duplicate parameters', () => {
         'http://lifeomic.com/fhir/dataset|0bb18fef-4e2d-4b91-a623-09527265a8b3',
         'http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3',
       ],
+      pageSize: ['25'],
     },
   }));
   assertRequestId(result);

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -57,7 +57,7 @@ test('Can parse URLs without duplicates', () => {
       pageSize: '25',
       test: 'diffValue',
     },
-    multiValueQueryStringParameters: {},
+    multiValueQueryStringParameters: null,
   }));
   assertRequestId(result);
 });


### PR DESCRIPTION
According to the [docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format) a multi-value param should be separated by commas for the `queryStringParameters` field and all fields should be formatted as an array for `multiValueQueryStringParameters`. In my testing it seems that our lambdas take one or the other so all values should exist in both. 

I set the `multiValueQueryStringParameters` to null when there are no multi fields.