### PR TITLE
Don't duplicate Lambda Event Params

### DIFF
--- a/src/adapters/helpers/lambdaEvent.ts
+++ b/src/adapters/helpers/lambdaEvent.ts
@@ -21,8 +21,10 @@ export const lambdaEvent = (config: AlphaOptions, relativeUrl?: string) => {
   if (hasMultiValueParams) {
     Object.entries(params).forEach(([key, value]) => {
       multiValueParams = multiValueParams || {};
-      multiValueParams[key] = Array.isArray(value) ? value : [value];
-      params[key] = Array.isArray(value) ? value.join(',') : value;
+      if (Array.isArray(value)) {
+        multiValueParams[key] = value;
+        delete params[key];
+      }
     });
   }
 

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -31,7 +31,6 @@ test('Can parse URLs with duplicate parameters', () => {
     httpMethod: 'GET',
     path: '/lifeomic/dstu3/Questionnaire',
     queryStringParameters: {
-      _tag: 'http://lifeomic.com/fhir/questionnaire-type|survey-form,http://lifeomic.com/fhir/dataset|0bb18fef-4e2d-4b91-a623-09527265a8b3,http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3',
       pageSize: '25',
     },
     multiValueQueryStringParameters: {
@@ -40,7 +39,6 @@ test('Can parse URLs with duplicate parameters', () => {
         'http://lifeomic.com/fhir/dataset|0bb18fef-4e2d-4b91-a623-09527265a8b3',
         'http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3',
       ],
-      pageSize: ['25'],
     },
   }));
   assertRequestId(result);


### PR DESCRIPTION
With version 7.0.1 a query string like `?a=1&a=2&b=3` would produce params like
```javascript
{
	queryStringParameters: { a: '1,2', b: '3' },
	multiValueQueryStringParameters: { a: ['1', '2'], b: ['3'] },
}
```

This change causes it to produce params like 
```javascript
{
	queryStringParameters: { b: '3' },
	multiValueQueryStringParameters: { a: ['1', '2'] },
}
```

The [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html) on the API Gateway Event does not provide details on what the expected function of each of these is so I am looking for input as well as proposing one potential solution (this PR). Here are the options as I see it.

1. Have alpha create events where array values are exclusively in `multiValueQueryStringParameters` and non-array values are in `queryStringParameters`
2. Restore the old behavior of just using `queryStringParameters` even though that would seem to go against the spec
3. Update the [logic](https://github.com/lifeomic/koa/blob/master/src/utils/normalizeParams.ts) in koa to not allow `serverless-http` to merge the keys that exist in both `multiValueQueryStringParameters` and  `queryStringParameters`, i.e. prioritize params from `multiValueQueryStringParameters`
4. Something else?

The reason for this change is that patient-service is getting events that look like this
```javascript
{
  queryStringParameters: {
    _tag: 'http://lifeomic.com/fhir/dataset|1234,http://lifeomic.com/fhir/source|LifeOmic%20Consent'
  },
  multiValueQueryStringParameters: {
    _tag: [
      'http://lifeomic.com/fhir/dataset|1234',
      'http://lifeomic.com/fhir/source|LifeOmic%20Consent'
    ]
  },
}
```

And when the params are parsed it has the following for `ctx.query`
```javascript
{
  _tag: [
    'http://lifeomic.com/fhir/dataset|1234',
    'http://lifeomic.com/fhir/source|LifeOmic%20Consent', 
    'http://lifeomic.com/fhir/dataset|1234,http://lifeomic.com/fhir/source|LifeOmic%20Consent'
  ],
}
```

This causes the error because it has a tag filter with a `,` which is not allowed.
