### PR TITLE
fix: Remove multiValueQueryStringParameters Logic

### DIFF
--- a/src/adapters/helpers/lambdaEvent.ts
+++ b/src/adapters/helpers/lambdaEvent.ts
@@ -13,20 +13,7 @@ export const lambdaEvent = (config: AlphaOptions, relativeUrl?: string) => {
     'http://fake',
     querystringWithArraySupport,
   );
-  const params: Record<string, any> = Object.assign({}, parts.query, config.params);
-  let multiValueParams: Record<string, any[]> | null = null;
-
-  const hasMultiValueParams = Object.values(params).some((value) => Array.isArray(value));
-
-  if (hasMultiValueParams) {
-    Object.entries(params).forEach(([key, value]) => {
-      multiValueParams = multiValueParams || {};
-      if (Array.isArray(value)) {
-        multiValueParams[key] = value;
-        delete params[key];
-      }
-    });
-  }
+  const params = Object.assign({}, parts.query, config.params);
 
   const httpMethod = (config.method as string).toUpperCase();
   const requestTime = new Date();
@@ -77,7 +64,7 @@ export const lambdaEvent = (config: AlphaOptions, relativeUrl?: string) => {
         userArn: null,
       },
     },
-    multiValueQueryStringParameters: multiValueParams,
+    multiValueQueryStringParameters: null,
   };
 
   if (Buffer.isBuffer(event.body)) {

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -31,14 +31,12 @@ test('Can parse URLs with duplicate parameters', () => {
     httpMethod: 'GET',
     path: '/lifeomic/dstu3/Questionnaire',
     queryStringParameters: {
-      pageSize: '25',
-    },
-    multiValueQueryStringParameters: {
       _tag: [
         'http://lifeomic.com/fhir/questionnaire-type|survey-form',
         'http://lifeomic.com/fhir/dataset|0bb18fef-4e2d-4b91-a623-09527265a8b3',
         'http://lifeomic.com/fhir/primary|0343bfcf-4e2d-4b91-a623-095272783bf3',
       ],
+      pageSize: '25',
     },
   }));
   assertRequestId(result);
@@ -57,7 +55,6 @@ test('Can parse URLs without duplicates', () => {
       pageSize: '25',
       test: 'diffValue',
     },
-    multiValueQueryStringParameters: null,
   }));
   assertRequestId(result);
 });


### PR DESCRIPTION
This reverts the logic to split query params into separate variables because it is not backwards compatible with older services.

Koa has been [updated](https://github.com/lifeomic/koa/pull/161) to continue to support array values in `queryStringParameters` so these changes are no longer needed.