### PR TITLE
fix: don't include undefined headers in api gateway event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 .idea
 yarn-error.log
 src/utils/lambdaURLGrammar.ts
+.tool-versions

--- a/src/adapters/helpers/apiGateway.ts
+++ b/src/adapters/helpers/apiGateway.ts
@@ -6,23 +6,26 @@ import { APIGatewayProxyEvent } from 'aws-lambda';
  * Needed for invoking @vendia/serverless-express handlers.
  * https://github.com/apollographql/apollo-server/issues/5504
  */
-export type ToProxyHeaders = Pick<APIGatewayProxyEvent, 'multiValueHeaders' | 'headers'>;
-export const toProxyHeaders = (headers: RawAxiosRequestHeaders = {}): ToProxyHeaders => {
+export type ToProxyHeaders = Pick<
+  APIGatewayProxyEvent,
+  'multiValueHeaders' | 'headers'
+>;
+export const toProxyHeaders = (
+  headers: RawAxiosRequestHeaders = {},
+): ToProxyHeaders => {
   const response: ToProxyHeaders = {
     multiValueHeaders: {},
     headers: {},
   };
-  Object.entries(headers).forEach(([key, value]) => {
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
     if (typeof value === 'string') {
       response.headers[key] = value;
       response.multiValueHeaders[key] = value.split(',').map((v) => v.trim());
-    } else if (value !== undefined) {
-      response.headers[key] = `${value}`;
-      response.multiValueHeaders[key] = [`${value}`];
     } else {
-      response.headers[key] = value;
-      response.multiValueHeaders[key] = value;
+      response.headers[key] = String(value);
+      response.multiValueHeaders[key] = [String(value)];
     }
-  });
+  }
   return response;
 };


### PR DESCRIPTION
When passing a `@lifeomic/koa` handler to `Alpha` (e.g. for unit testing the koa app), there is an issue with `serverless-http` (a dependency of `@lifeomic/koa`) which expects API Gateway events to not have undefined header values. This PR fixes that compatibility issue by filtering out undefined headers when constructing the synthetic API Gateway event.