### PR TITLE
[EOCI-745] prevent recursive range error on redirects

### DIFF
--- a/src/alpha.ts
+++ b/src/alpha.ts
@@ -1,16 +1,16 @@
-import pick from 'lodash/pick';
 import merge from 'lodash/merge';
+import pick from 'lodash/pick';
 
+import { Handler } from 'aws-lambda';
 import axios, { Axios, AxiosAdapter, AxiosHeaders, AxiosResponse } from 'axios';
 import cloneDeep from 'lodash/cloneDeep';
 import { AlphaOptions, AlphaResponse, HandlerRequest } from './types';
-import { Handler } from 'aws-lambda';
 
-import { adapters } from './adapters';
-import { interceptors } from './interceptors';
-import { RequestError } from './adapters/helpers/requestError';
-import { resolve } from './resolve';
 import { InvocationRequest } from '@aws-sdk/client-lambda';
+import { adapters } from './adapters';
+import { RequestError } from './adapters/helpers/requestError';
+import { interceptors } from './interceptors';
+import { resolve } from './resolve';
 
 const ALPHA_CONFIG = ['adapter', 'lambda', 'Lambda', 'retry', '__retryCount'];
 
@@ -72,7 +72,12 @@ export class Alpha extends Axios {
 
     const castResp = response as any as AxiosResponse;
 
-    if (castResp.status === 301 || castResp.status === 302) {
+    const redirectUrl = castResp.headers.location as string;
+
+    if (
+      (castResp.status === 301 || castResp.status === 302) &&
+      redirectUrl
+    ) {
       if (maxRedirects === 0) {
         const request = castResp.request as InvocationRequest | HandlerRequest;
         throw new RequestError('Exceeded maximum number of redirects.', castResp.config, request, castResp);
@@ -80,7 +85,13 @@ export class Alpha extends Axios {
 
       const redirect = cloneDeep(config);
       redirect.maxRedirects = maxRedirects - 1;
-      redirect.url = resolve(castResp.headers.location as string, castResp.config.url);
+      redirect.url = resolve(redirectUrl, castResp.config.url);
+
+      // Prevent recursive loops
+      if (redirect.url === config.url) {
+        return response as R;
+      }
+
       return this.request(redirect);
     }
 

--- a/test/redirects.test.ts
+++ b/test/redirects.test.ts
@@ -1,7 +1,7 @@
-import { Alpha } from '../src';
-import nock from 'nock';
 import { InvokeCommand, Lambda } from '@aws-sdk/client-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
+import nock from 'nock';
+import { Alpha } from '../src';
 import { createResponse, prepResponse } from './utils';
 
 const mockLambda = mockClient(Lambda);
@@ -170,4 +170,21 @@ test('Redirects can be explicitly limited', async () => {
   expect(error.response.status).toBe(302);
   expect(error.response.headers.location).toBe('/two');
   expect(server.isDone()).toBe(true);
+});
+
+test('A Lambda should not follow a redirect back to itself', async () => {
+  createResponse(mockLambda, {
+    StatusCode: 200,
+    Payload: {
+      headers: { location: 'lambda://test' },
+      statusCode: 302,
+    },
+  });
+
+  const response = await ctx.alpha.get('lambda://test');
+
+  // The desired behavior is to receive the 302 response, not to recursively follow it.
+  expect(response.status).toBe(302);
+  // Ensure we only called the lambda once.
+  expect(mockLambda.commandCalls(InvokeCommand)).toHaveLength(1);
 });


### PR DESCRIPTION
`graphql-proxy-service` will sometimes error with a `RangeError: Maximum call stack size exceeded`. The log's call stack points to an infinite recursive loop within the @lifeomic/alpha client's request method. 

The errors occur in the chat agent callstack from various user-agents but its very difficult to tell why. ([logs](https://service.us2.sumologic.com/log-search/create?id=T3LyoJ0MRMV32FtSts9orO3Rvz0TQlBMgOn6PPQD)). Bugsnag is reporting these as 502's from flma, but from the logs we can see its not limited to the member app.

Looking back in the logs and matching up dates with changes, it also may have started after introducing [thinking mode](https://github.com/lifeomic/agents/pull/1034). 

Reviewing the code, the conclusion is that the client is receiving a 301 or 302 response, causing it to re-call itself with the same parameters, leading to the crash. The specific flaw is that the client does not have a safeguard to detect when a redirect points back to the original URL.

The logic now checks if the resolved redirect URL is identical to the original request URL. If they are the same, the redirect chain is immediately broken, and the response is returned to the caller.

This should replace the crash with a non-fatal application error (the returned 302 response). This makes the system stable and allows for safe investigation into which downstream service is issuing the redirect.